### PR TITLE
Feature/reinit listeners

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -208,8 +208,12 @@ func waitBusy(b transport.BusyChannelChecker) {
 }
 
 func initWinmorTNC() error {
-	if wmTNC != nil {
+	if wmTNC != nil && wmTNC.Ping() == nil {
 		return nil
+	}
+
+	if wmTNC != nil {
+		wmTNC.Close()
 	}
 
 	var err error
@@ -240,8 +244,12 @@ func initWinmorTNC() error {
 }
 
 func initArdopTNC() error {
-	if adTNC != nil {
+	if adTNC != nil && adTNC.Ping() == nil {
 		return nil
+	}
+
+	if adTNC != nil {
+		adTNC.Close()
 	}
 
 	var err error

--- a/http.go
+++ b/http.go
@@ -309,13 +309,13 @@ func uiHandler(w http.ResponseWriter, r *http.Request) {
 
 func getStatus() Status {
 	status := Status{
-		ActiveListeners: make([]string, 0, len(listeners)),
+		ActiveListeners: []string{},
 		Connected:       exchangeConn != nil,
 		HTTPClients:     websocketHub.ClientAddrs(),
 	}
 
-	for method := range listeners {
-		status.ActiveListeners = append(status.ActiveListeners, method)
+	for _, tl := range listenHub.Active() {
+		status.ActiveListeners = append(status.ActiveListeners, tl.Name())
 	}
 	sort.Strings(status.ActiveListeners)
 

--- a/interactive.go
+++ b/interactive.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"sort"
 	"strings"
 	"time"
 
@@ -96,14 +95,10 @@ func printInteractiveUsage() {
 func getPrompt() string {
 	var buf bytes.Buffer
 
-	methods := make([]string, 0, len(listeners))
-	for method := range listeners {
-		methods = append(methods, method)
-	}
+	status := getStatus()
 
-	if len(listeners) > 0 {
-		sort.Strings(methods)
-		fmt.Fprintf(&buf, "L%v", methods)
+	if len(status.ActiveListeners) > 0 {
+		fmt.Fprintf(&buf, "L%v", status.ActiveListeners)
 	}
 
 	fmt.Fprint(&buf, "> ")

--- a/interactive.go
+++ b/interactive.go
@@ -8,6 +8,8 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -56,6 +58,10 @@ func execCmd(line string) (quit bool) {
 		freq(param)
 	case "qtc":
 		PrintQTC()
+	case "debug":
+		os.Setenv("ardop_debug", "1")
+		os.Setenv("winmor_debug", "1")
+		fmt.Println("Number of goroutines:", runtime.NumGoroutine())
 	case "q", "quit":
 		return true
 	case "":

--- a/listener_hub.go
+++ b/listener_hub.go
@@ -1,0 +1,195 @@
+// Copyright 2017 Martin Hebnes Pedersen (LA5NTA). All rights reserved.
+// Use of this source code is governed by the MIT-license that can be
+// found in the LICENSE file.
+
+package main
+
+import (
+	"log"
+	"net"
+	"sync"
+	"time"
+)
+
+type TransportListener interface {
+	Init() (net.Listener, error)
+	Name() string
+	CurrentFreq() (Frequency, bool)
+}
+
+type Beaconer interface {
+	BeaconStop()
+	BeaconStart() error
+}
+
+type Listener struct {
+	t   TransportListener
+	hub *ListenerHub
+
+	mu       sync.Mutex
+	isClosed bool
+	err      error
+	ln       net.Listener
+}
+
+func NewListener(t TransportListener) *Listener { return &Listener{t: t} }
+
+func (l *Listener) Err() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.err
+}
+
+func (l *Listener) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.isClosed {
+		return l.err
+	}
+	l.isClosed = true
+
+	// If l.err is not nil, then the last attempt to open the listener failed and we don't have anything to close
+	if l.err != nil {
+		return l.err
+	}
+	return l.ln.Close()
+}
+
+func (l *Listener) listenLoop() {
+	var silenceErr bool
+	for {
+		l.mu.Lock()
+		if l.isClosed {
+			l.mu.Unlock()
+			break
+		}
+
+		// Try to init the TNC
+		l.ln, l.err = l.t.Init()
+		if l.err != nil {
+			l.mu.Unlock()
+			if !silenceErr {
+				log.Printf("Listener %s failed: %s", l.t.Name(), l.err)
+				log.Printf("Will try to re-establish listener in the background...")
+				silenceErr = true
+				websocketHub.UpdateStatus()
+			}
+			time.Sleep(time.Second)
+			continue
+		}
+		l.mu.Unlock()
+		if silenceErr {
+			log.Printf("Listener %s re-established", l.t.Name())
+			silenceErr = false
+			websocketHub.UpdateStatus()
+		}
+
+		if b, ok := l.t.(Beaconer); ok {
+			b.BeaconStart()
+		}
+
+		// Run the accept loop until an error occures
+		if err := l.acceptLoop(); err != nil {
+			log.Printf("Accept %s failed: %s", l.t.Name(), err)
+		}
+
+		if b, ok := l.t.(Beaconer); ok {
+			b.BeaconStop()
+		}
+	}
+}
+
+type RemoteCaller interface {
+	RemoteCall() string
+}
+
+func (l *Listener) acceptLoop() error {
+	for {
+		conn, err := l.ln.Accept()
+		if err != nil {
+			return err
+		}
+
+		remoteCall := conn.RemoteAddr().String()
+		if c, ok := conn.(RemoteCaller); ok {
+			remoteCall = c.RemoteCall()
+		}
+
+		freq, _ := l.t.CurrentFreq()
+
+		eventLog.LogConn("accept", freq, conn, nil)
+		log.Printf("Got connect (%s:%s)", l.t.Name(), remoteCall)
+
+		err = exchange(conn, remoteCall, true)
+		if err != nil {
+			log.Printf("Exchange failed: %s", err)
+		} else {
+			log.Println("Disconnected.")
+		}
+	}
+}
+
+type ListenerHub struct {
+	mu        sync.Mutex
+	listeners map[string]*Listener
+}
+
+func NewListenerHub() *ListenerHub {
+	return &ListenerHub{
+		listeners: map[string]*Listener{},
+	}
+}
+
+func (h *ListenerHub) Active() []TransportListener {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	slice := make([]TransportListener, 0, len(h.listeners))
+	for _, l := range h.listeners {
+		if l.Err() != nil {
+			continue
+		}
+		slice = append(slice, l.t)
+	}
+	return slice
+}
+
+func (h *ListenerHub) Enable(t TransportListener) {
+	h.mu.Lock()
+	defer func() {
+		h.mu.Unlock()
+		websocketHub.UpdateStatus()
+	}()
+	l := NewListener(t)
+	if _, ok := h.listeners[t.Name()]; ok {
+		return
+	}
+	h.listeners[t.Name()] = l
+	go l.listenLoop()
+}
+
+func (h *ListenerHub) Disable(name string) (bool, error) {
+	h.mu.Lock()
+	defer func() {
+		h.mu.Unlock()
+		websocketHub.UpdateStatus()
+	}()
+	l, ok := h.listeners[name]
+	if !ok {
+		return false, nil
+	}
+	delete(h.listeners, name)
+	return true, l.Close()
+}
+
+func (h *ListenerHub) Close() {
+	h.mu.Lock()
+	defer func() {
+		h.mu.Unlock()
+		websocketHub.UpdateStatus()
+	}()
+	for k, l := range h.listeners {
+		l.Close()
+		delete(h.listeners, k)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -140,10 +140,10 @@ var (
 	logWriter io.Writer
 	eventLog  *EventLogger
 
-	exchangeChan chan ex                 // The channel that the exchange loop is listening on
-	exchangeConn net.Conn                // Pointer to the active session connection (exchange)
-	listeners    map[string]net.Listener // Active listeners
-	mbox         *mailbox.DirHandler     // The mailbox
+	exchangeChan chan ex             // The channel that the exchange loop is listening on
+	exchangeConn net.Conn            // Pointer to the active session connection (exchange)
+	mbox         *mailbox.DirHandler // The mailbox
+	listenHub    *ListenerHub
 	appDir       string
 )
 
@@ -181,7 +181,7 @@ func optionsSet() *pflag.FlagSet {
 }
 
 func init() {
-	listeners = make(map[string]net.Listener)
+	listenHub = NewListenerHub()
 
 	var err error
 	appDir, err = mailbox.DefaultAppDir()
@@ -388,9 +388,7 @@ func helpHandle(args []string) {
 }
 
 func cleanup() {
-	for method := range listeners {
-		Unlisten(method)
-	}
+	listenHub.Close()
 
 	if wmTNC != nil {
 		if err := wmTNC.Close(); err != nil {


### PR DESCRIPTION
This is a complete make-over of how Pat manages it's P2P listeners, so that we can gracefully handle TNCs and devices that are temporarily unavailable.

It also adds a new (undocumented) debug command to the interactive CLI interface that enables trace logging of ARDOP and WINMOR TNC communications.

Closes #88 when merged to master.