### PR TITLE
Changing pactor url scheme from ptc:// to pactor://

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -53,7 +53,7 @@ type Config struct {
 	SerialTNC SerialTNCConfig `json:"serial-tnc"` // See SerialTNCConfig.
 	Winmor    WinmorConfig    `json:"winmor"`     // See WinmorConfig.
 	Ardop     ArdopConfig     `json:"ardop"`      // See ArdopConfig.
-	PTC       PTCConfig       `json:"ptc"`        // See PTCConfig.
+	Pactor    PactorConfig    `json:"pactor"`     // See PactorConfig.
 	Telnet    TelnetConfig    `json:"telnet"`     // See TelnetConfig.
 
 	// Address and port to a GPSd daemon for position reporting.
@@ -132,7 +132,7 @@ type ArdopConfig struct {
 	CWID bool `json:"cwid_enabled"`
 }
 
-type PTCConfig struct {
+type PactorConfig struct {
 	// Path/port to TNC device (e.g. /dev/ttyUSB0 or COM1).
 	Path string `json:"path"`
 
@@ -217,7 +217,7 @@ var DefaultConfig Config = Config{
 		ARQBandwidth: ardop.Bandwidth500Max,
 		CWID:         true,
 	},
-	PTC: PTCConfig{
+	Pactor: PactorConfig{
 		Path:     "/dev/ttyUSB0",
 		Baudrate: 57600,
 	},

--- a/connect.go
+++ b/connect.go
@@ -79,16 +79,16 @@ func Connect(connectStr string) (success bool) {
 			if config.SerialTNC.Baudrate > 0 {
 				url.Params.Set("hbaud", fmt.Sprint(config.SerialTNC.Baudrate))
 			}
-		case "ptc":
-			url.Host = config.PTC.Path
-			if config.PTC.Baudrate > 0 {
-				url.Params.Set("baud", fmt.Sprint(config.PTC.Baudrate))
+		case "pactor":
+			url.Host = config.Pactor.Path
+			if config.Pactor.Baudrate > 0 {
+				url.Params.Set("baud", fmt.Sprint(config.Pactor.Baudrate))
 			}
 		}
 	}
 
-	if url.Scheme == "ptc" && config.PTC.InitScript != "" && url.Params.Get("init_script") == "" {
-		url.Params.Set("init_script", config.PTC.InitScript)
+	if url.Scheme == "pactor" && config.Pactor.InitScript != "" && url.Params.Get("init_script") == "" {
+		url.Params.Set("init_script", config.Pactor.InitScript)
 	}
 
 	// Radio Only?
@@ -172,8 +172,8 @@ func qsy(method, addr string) (revert func(), err error) {
 		rigName = config.Ardop.Rig
 	case MethodAX25:
 		rigName = config.AX25.Rig
-	case MethodPTC:
-		rigName = config.PTC.Rig
+	case MethodPactor:
+		rigName = config.Pactor.Rig
 	default:
 		return noop, fmt.Errorf("Not supported with transport '%s'", method)
 	}

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ const (
 	MethodTelnet    = "telnet"
 	MethodAX25      = "ax25"
 	MethodSerialTNC = "serial-tnc"
-	MethodPTC       = "ptc"
+	MethodPactor    = "pactor"
 )
 
 var commands = []Command{


### PR DESCRIPTION
this is to follow the requst made https://github.com/harenber/ptc-go/issues/12 (which came from here: https://github.com/la5nta/pat/pull/145#issuecomment-443198278 ). It also updates the submodule "harenber/ptc-go" to the current HEAD of this repository.