### PR TITLE
Add the tmd710-tncsetup script as a suggest

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,4 +11,5 @@ Architecture: amd64 i386 armhf
 Conflicts: wl2k-go, dist
 Replaces: wl2k-go
 Recommends: libhamlib-utils (>= 1.2), ax25-tools, gpsd (>= 2.90)
+Suggests: tmd710-tncsetup
 Description: A portable Winlink client for amateur radio email.


### PR DESCRIPTION
The script that is referenced in `/etc/default/ax25` is now packaged for Debian: https://packages.debian.org/bullseye/tmd710-tncsetup