### PR TITLE
Add RMS list viewer in Web GUI

### DIFF
--- a/freq.go
+++ b/freq.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"strconv"
@@ -47,6 +48,19 @@ func (f Frequency) String() string {
 	k := (float64(f) - float64(m)*1e6) / 1e3
 
 	return fmt.Sprintf("%d.%06.2f MHz", m, k)
+}
+
+func (f Frequency) MarshalJSON() ([]byte, error) {
+	type obj struct {
+		Hz   json.Number `json:"hz"`
+		KHz  json.Number `json:"khz"`
+		Desc string      `json:"desc"`
+	}
+	return json.Marshal(obj{
+		Hz:   json.Number(fmt.Sprint(int(f))),
+		KHz:  json.Number(fmt.Sprint(f.KHz())),
+		Desc: f.String(),
+	})
 }
 
 func (f Frequency) KHz() float64 { return float64(f) / 1e3 }

--- a/freq.go
+++ b/freq.go
@@ -91,16 +91,25 @@ func (f Frequency) Dial(mode string) Frequency {
 	return f + shift
 }
 
-func VFOForTransport(transport string) (vfo hamlib.VFO, ok bool) {
+func VFOForTransport(transport string) (vfo hamlib.VFO, rigName string, ok bool, err error) {
+	var rig string
 	switch transport {
 	case MethodWinmor:
-		vfo, ok = rigs[config.Winmor.Rig]
+		rig = config.Winmor.Rig
 	case MethodArdop:
-		vfo, ok = rigs[config.Ardop.Rig]
+		rig = config.Ardop.Rig
 	case MethodAX25:
-		vfo, ok = rigs[config.AX25.Rig]
+		rig = config.AX25.Rig
+	case MethodPactor:
+		rig = config.Pactor.Rig
+	default:
+		return vfo, "", false, fmt.Errorf("Not supported with transport '%s'", transport)
 	}
-	return
+	if rig == "" {
+		return vfo, "", false, fmt.Errorf("Missing rig reference in config section for %s", transport)
+	}
+	vfo, ok = rigs[rig]
+	return vfo, rig, ok, nil
 }
 
 func freq(param string) {
@@ -109,7 +118,7 @@ func freq(param string) {
 		fmt.Println("Need freq method.")
 	}
 
-	rig, ok := VFOForTransport(parts[0])
+	rig, _, ok, _ := VFOForTransport(parts[0])
 	if !ok {
 		log.Printf("Hamlib rig not loaded.")
 		return

--- a/res/js/index.js
+++ b/res/js/index.js
@@ -221,18 +221,76 @@ function initComposeModal() {
 }
 
 function initConnectModal() {
-	$('#freqInput').change(onConnectInputChange);
+	$('#freqInput').change(() => {
+		onConnectInputChange();
+		onConnectFreqChange();
+	});
 	$('#radioOnlyInput').change(onConnectInputChange);
 	$('#addrInput').change(onConnectInputChange);
 	$('#targetInput').change(onConnectInputChange);
+	$('#updateRmslistButton').click((e) => {
+		$(e.target).prop('disabled', true);
+		updateRmslist(true);
+	});
 
-	$('#transportSelect').change(function() {
+	$('#modeSearchSelect').change(updateRmslist);
+	$('#bandSearchSelect').change(updateRmslist);
+
+	$('#transportSelect').change(function(e) {
 		refreshExtraInputGroups();
 		onConnectInputChange();
+		onConnectFreqChange();
+		switch( $(e.target).val() ){
+			case "ardop":
+			case "winmor":
+			case "pactor":
+				$('#modeSearchSelect').val($(e.target).val());
+				break;
+			case "serial-tnc":
+			case "ax25":
+				$('#modeSearchSelect').val("packet");
+				break;
+			default:
+				return;
+		}
+		$('#modeSearchSelect').selectpicker('refresh');
+		updateRmslist();
 	});
 	refreshExtraInputGroups();
 
 	updateConnectAliases();
+	updateRmslist();
+}
+
+function updateRmslist(forceDownload) {
+	let tbody = $('#rmslist tbody');
+	let params = {
+		'mode': $('#modeSearchSelect').val(),
+		'band': $('#bandSearchSelect').val(),
+		'force-download': forceDownload === true,
+	};
+	$.ajax({
+		method: "GET",
+		url: "/api/rmslist",
+		dataType: "json",
+		data: params,
+		success: function(data){
+			tbody.empty();
+			data.forEach((rms) => {
+				let tr = $('<tr>')
+					.append($('<td class="text-left">').text(rms.callsign))
+					.append($('<td class="text-left">').text(rms.distance.toFixed(0) + " km"))
+					.append($('<td class="text-left">').text(rms.modes))
+					.append($('<td class="text-right">').text(rms.dial.desc));
+				tr.click((e) => {
+					tbody.find('.active').removeClass('active');
+					tr.addClass('active');
+					setConnectValues(rms.url);
+				});
+				tbody.append(tr);
+			});
+		},
+	});
 }
 
 function updateConnectAliases() {
@@ -292,7 +350,9 @@ function setConnectValues(url) {
 	}
 	$('#addrInput').val(usri + url.host());
 
+	refreshExtraInputGroups();
 	onConnectInputChange();
+	onConnectFreqChange();
 }
 
 function getConnectURL() {
@@ -300,7 +360,7 @@ function getConnectURL() {
 
 	params = "";
 
-	if($('#freqInput').val()) {
+	if($('#freqInput').val() && $('#freqInput').parent().hasClass('has-success')) {
 		params += "&freq=" + $('#freqInput').val();
 	}
 	if($('#radioOnlyInput').is(':checked')) {
@@ -312,6 +372,38 @@ function getConnectURL() {
 	}
 
 	return url;
+}
+
+function onConnectFreqChange() {
+	const data = {
+		transport: $('#transportSelect').val(),
+		freq:      new Number($('#freqInput').val()),
+	};
+	if(data.freq == 0) {
+		return;
+	}
+
+	const inputGroup = $('#freqInput').parent();
+	['has-error', 'has-success', 'has-warning'].forEach((v) => {
+		inputGroup.removeClass(v);
+	});
+
+	console.log("QSY: " + JSON.stringify(data));
+	$.ajax({
+		method: "POST",
+		url: "/api/qsy",
+		data: JSON.stringify(data),
+		contentType: "application/json",
+		success: () => { inputGroup.addClass('has-success'); },
+		error: (xhr) => {
+			if(xhr.status == 503) {
+				// The feature is unavailable
+			} else {
+				inputGroup.addClass('has-error');
+			}
+		},
+		complete: () => { onConnectInputChange(); }, // This removes freq= from URL in case of failure
+	});
 }
 
 function onConnectInputChange() {

--- a/res/site.css
+++ b/res/site.css
@@ -11,6 +11,10 @@ body > .container {
   padding: 75px 15px 0;
 }
 
+.btn:focus {
+  outline: none !important;
+}
+
 .status-text {
   font-weight: bold;
   font-size: 11px !important;
@@ -303,3 +307,6 @@ input[type=checkbox], input[type=radio]
   margin: 0;
   padding: 0;
 }
+
+.table-fixed          { overflow-y: auto; height: 400px; }
+.table-fixed thead th { position: sticky; top: 0; background: #eee; }

--- a/res/tmpl/index.html
+++ b/res/tmpl/index.html
@@ -177,12 +177,62 @@
                   </div>
                 </div>
               </form>
+              <span id="connectURLPreview" style="float: left; position: relative; bottom: 5px; color: gray;"></span>
             </div>
             <div class="modal-footer">
-			  <p id="connectURLPreview" class="pull-left"></p>
+              <button type="button" class="btn btn-default btn-sm pull-left" data-toggle="collapse" data-target="#rmslist-container">Show RMS list</button>
               <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
               <button type="button" class="btn btn-primary" id="connect_btn">Connect</button>
-            </div>
+	    </div>
+            <div class="modal-footer collapse" id="rmslist-container">
+              <div class="form-group row">
+                <div class="col-md-4">
+                  <select class="selectpicker form-control" data-width="100%" id="modeSearchSelect">
+                    <optgroup label="mode">
+                      <option value="">(any mode)</option>
+                      <option value="ardop" selected>ARDOP</option>
+                      <option value="packet">Packet</option>
+                      <option value="pactor">Pactor</option>
+                      <option value="winmor">WINMOR</option>
+                    </optgroup>
+                  </select>
+                </div>
+                <div class="col-md-4">
+                  <select class="selectpicker form-control" data-width="100%" id="bandSearchSelect">
+                    <optgroup label="band">
+                      <!-- Values from freq.go -->
+                      <option value="">(any band)</option>
+                      <option value="160m">160m</option>
+                      <option value="80m">80m</option>
+                      <option value="60m">60m</option>
+                      <option value="40m">40m</option>
+                      <option value="30m">30m</option>
+                      <option value="20m">20m</option>
+                      <option value="17m">17m</option>
+                      <option value="15m">15m</option>
+                      <option value="12m">12m</option>
+                      <option value="10m">10m</option>
+                      <option value="6m">6m</option>
+                      <option value="4m">4m</option>
+                      <option value="2m">2m</option>
+                      <option value="1.25m">1.25m</option>
+                      <option value="70cm">70cm</option>
+                    </optgroup>
+                  </select>
+                </div>
+                <div class="col-md-4">
+                  <button id="updateRmslistButton" class="btn btn-default btn-link">Update cache</button>
+                </div>
+              </div>
+              <div class="table-responsive table-fixed">
+                <table id="rmslist" class="table table-hover table-condensed">
+                  <thead>
+                    <tr><th>target</th><th>distance</th><th>mode</th><th class="text-right">dial freq</th></tr>
+                  </thead>
+                  <tbody></tbody> <!-- This is populated by javascript -->
+                </table>
+	      </div>
+	    </div>
           </div>
         </div>
       </div>

--- a/rmslist.go
+++ b/rmslist.go
@@ -35,7 +35,7 @@ type RMS struct {
 	Modes      string    `json:"modes"`
 	Freq       Frequency `json:"freq"`
 	Dial       Frequency `json:"dial"`
-	URL        *JSONURL  `json"url"`
+	URL        *JSONURL  `json:"url"`
 }
 
 func (r RMS) IsMode(mode string) bool {

--- a/rmslist.go
+++ b/rmslist.go
@@ -115,8 +115,6 @@ func rmsListHandle(args []string) {
 			case !bands[*band].Contains(f):
 				continue
 			}
-			r.distance = float64(0)
-			r.azimuth = float64(0)
 			if !noLocator {
 				if them, err := maidenhead.ParseLocator(channel.Gridsquare); err == nil {
 					r.distance = me.Distance(them)

--- a/rmslist.go
+++ b/rmslist.go
@@ -23,22 +23,34 @@ import (
 	"github.com/pd0mz/go-maidenhead"
 )
 
-type rms struct {
-	callsign string
-	gridsq   string
-	distance float64
-	azimuth  float64
-	modes    string
-	freq     string
-	dial     string
-	url      *url.URL
+type JSONURL struct{ url.URL }
+
+func (url JSONURL) MarshalJSON() ([]byte, error) { return json.Marshal(url.String()) }
+
+type RMS struct {
+	Callsign   string    `json:"callsign"`
+	Gridsquare string    `json:"gridsquare"`
+	Distance   float64   `json:"distance"`
+	Azimuth    float64   `json:"azimuth"`
+	Modes      string    `json:"modes"`
+	Freq       Frequency `json:"freq"`
+	Dial       Frequency `json:"dial"`
+	URL        *JSONURL  `json"url"`
 }
 
-type byDist []rms
+func (r RMS) IsMode(mode string) bool {
+	return strings.Contains(strings.ToLower(r.Modes), mode)
+}
+
+func (r RMS) IsBand(band string) bool {
+	return bands[band].Contains(r.Freq)
+}
+
+type byDist []RMS
 
 func (r byDist) Len() int           { return len(r) }
 func (r byDist) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
-func (r byDist) Less(i, j int) bool { return r[i].distance < r[j].distance }
+func (r byDist) Less(i, j int) bool { return r[i].Distance < r[j].Distance }
 
 func rmsListHandle(args []string) {
 	set := pflag.NewFlagSet("rmslist", pflag.ExitOnError)
@@ -47,6 +59,55 @@ func rmsListHandle(args []string) {
 	forceDownload := set.BoolP("force-download", "d", false, "")
 	byDistance := set.BoolP("sort-distance", "s", false, "")
 	set.Parse(args)
+
+	var query string
+	if len(set.Args()) > 0 {
+		query = strings.ToUpper(set.Args()[0])
+	}
+
+	*mode = strings.ToLower(*mode)
+	rList, err := ReadRMSList(*forceDownload, func(rms RMS) bool {
+		switch {
+		case query != "" && !strings.HasPrefix(rms.Callsign, query):
+			return false
+		case mode != nil && !rms.IsMode(*mode):
+			return false
+		case band != nil && !rms.IsBand(*band):
+			return false
+		default:
+			return true
+		}
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	if *byDistance {
+		sort.Sort(byDist(rList))
+	}
+
+	fmtStr := "%-9.9s [%-6.6s] %-6.6s %3.3s %-15.15s %14.14s %14.14s %s\n"
+
+	// Print header
+	fmt.Printf(fmtStr, "callsign", "gridsq", "dist", "Az", "mode(s)", "dial freq", "center freq", "url")
+
+	// Print gateways (separated by blank line)
+	for i := 0; i < len(rList); i++ {
+		r := rList[i]
+		distance := strconv.FormatFloat(r.Distance, 'f', 0, 64)
+		azimuth := strconv.FormatFloat(r.Azimuth, 'f', 0, 64)
+
+		fmt.Printf(fmtStr, r.Callsign, r.Gridsquare, distance, azimuth, r.Modes, r.Dial, r.Freq, r.URL)
+		if i+1 < len(rList) && rList[i].Callsign != rList[i+1].Callsign {
+			fmt.Println("")
+		}
+	}
+}
+
+func ReadRMSList(forceDownload bool, filterFn func(rms RMS) (keep bool)) ([]RMS, error) {
+	me, err := maidenhead.ParseLocator(config.Locator)
+	if err != nil {
+		log.Print("Missing or Invalid Locator, will not compute distance and Azimuth")
+	}
 
 	appDir, err := mailbox.DefaultAppDir()
 	if err != nil {
@@ -59,97 +120,45 @@ func rmsListHandle(args []string) {
 	}
 	filePath := path.Join(appDir, fileName+".json") // Should be moved to a tmp-folder, along with logfile.
 
-	var query string
-	if len(set.Args()) > 0 {
-		query = strings.ToUpper(set.Args()[0])
-	}
-
-	file, err := cmsapi.GetGatewayStatusCached(filePath, *forceDownload, config.ServiceCodes...)
+	f, err := cmsapi.GetGatewayStatusCached(filePath, forceDownload, config.ServiceCodes...)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
-	defer file.Close()
-
+	defer f.Close()
 	var status cmsapi.GatewayStatus
-
-	err = json.NewDecoder(file).Decode(&status)
-	if err != nil {
-		log.Fatal(err)
+	if err = json.NewDecoder(f).Decode(&status); err != nil {
+		return nil, err
 	}
 
-	noLocator := false
-
-	me, err := maidenhead.ParseLocator(config.Locator)
-	if err != nil {
-		log.Print("Missing or Invalid Locator, will not compute distance and Azimuth")
-		noLocator = true
-	}
-
-	*mode = strings.ToLower(*mode)
-
-	rList := []rms{}
-
-	// Print gateways (separated by blank line)
+	slice := []RMS{}
 	for _, gw := range status.Gateways {
-		switch {
-		case query != "" && !strings.HasPrefix(gw.Callsign, query):
-			continue
-		default:
-		}
-
 		for _, channel := range gw.Channels {
-
-			r := rms{
-				callsign: gw.Callsign,
-				gridsq:   channel.Gridsquare,
-				modes:    channel.SupportedModes,
+			r := RMS{
+				Callsign:   gw.Callsign,
+				Gridsquare: channel.Gridsquare,
+				Modes:      channel.SupportedModes,
+				Freq:       Frequency(channel.Frequency),
+				Dial:       Frequency(channel.Frequency).Dial(channel.SupportedModes),
 			}
-
-			f := Frequency(channel.Frequency)
-			r.dial = f.Dial(channel.SupportedModes).String()
-			r.freq = f.String()
-
-			switch {
-			case mode != nil && !strings.Contains(strings.ToLower(channel.SupportedModes), *mode):
+			if url := toURL(channel, gw.Callsign); url != nil {
+				r.URL = &JSONURL{*url}
+			}
+			hasLocator := me != maidenhead.Point{}
+			if them, err := maidenhead.ParseLocator(channel.Gridsquare); err == nil && hasLocator {
+				r.Distance = me.Distance(them)
+				r.Azimuth = me.Bearing(them)
+			}
+			if keep := filterFn(r); !keep {
 				continue
-			case !bands[*band].Contains(f):
-				continue
 			}
-			if !noLocator {
-				if them, err := maidenhead.ParseLocator(channel.Gridsquare); err == nil {
-					r.distance = me.Distance(them)
-					r.azimuth = me.Bearing(them)
-				}
-			}
-
-			r.url = toURL(channel, gw.Callsign)
-
-			rList = append(rList, r)
+			slice = append(slice, r)
 		}
 	}
-	if *byDistance {
-		sort.Sort(byDist(rList))
-	}
-	fmtStr := "%-9.9s [%-6.6s] %-6.6s %3.3s %-15.15s %14.14s %14.14s %s\n"
-
-	// Print header
-	fmt.Printf(fmtStr, "callsign", "gridsq", "dist", "Az", "mode(s)", "dial freq", "center freq", "url") //TODO: "center frequency" of packet is wrong...
-
-	for i := 0; i < len(rList); i++ {
-		r := rList[i]
-		distance := strconv.FormatFloat(r.distance, 'f', 0, 64)
-		azimuth := strconv.FormatFloat(r.azimuth, 'f', 0, 64)
-
-		fmt.Printf(fmtStr, r.callsign, r.gridsq, distance, azimuth, r.modes, r.dial, r.freq, r.url)
-		if i+1 < len(rList) && rList[i].callsign != rList[i+1].callsign {
-			fmt.Println("")
-		}
-	}
+	return slice, nil
 }
 
 func toURL(gc cmsapi.GatewayChannel, targetcall string) *url.URL {
 	freq := Frequency(gc.Frequency).Dial(gc.SupportedModes)
-
 	url, _ := url.Parse(fmt.Sprintf("%s:///%s?freq=%v", toTransport(gc), targetcall, freq.KHz()))
 	return url
 }


### PR DESCRIPTION
Improved connect modal with list of Winlink RMS nodes.

The table rows are selectable and will automatically configures the various input fields according to the selection. 

This also changes how the frequency input field is handled. Input changes now triggers QSY commands right away, and the response is interpreted to give the user a visual confirmation of the frequency change. If the QSY fails, the field is ignored when building the final connect URL so it won't cause an error when the user hits the connect button.

All in all, this should make it much more convenient to find and connect RMS nodes from the browser.