### PR TITLE
fixed #229 added support for azimuth NaN, which happens if distance is 0

### DIFF
--- a/http.go
+++ b/http.go
@@ -386,7 +386,11 @@ func rmslistHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	sort.Sort(byDist(list))
-	json.NewEncoder(w).Encode(list)
+	err = json.NewEncoder(w).Encode(list)
+	if err != nil {
+		log.Println(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func qsyHandler(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
For locator CN85pl the RMS list list on the connect dialog was not working correctly for Packet @ 2m. 
For K7GDS-10 the distance is 0 and azimuth is NaN. The JSON serializer couldn't deal with NaN. 