### PR TITLE
Fix inappropriate alpha sort on distance and frequency in RMS list

### DIFF
--- a/freq.go
+++ b/freq.go
@@ -46,7 +46,6 @@ type Frequency int // Hz
 func (f Frequency) String() string {
 	m := f / 1e6
 	k := (float64(f) - float64(m)*1e6) / 1e3
-
 	return fmt.Sprintf("%d.%06.2f MHz", m, k)
 }
 

--- a/res/js/index.js
+++ b/res/js/index.js
@@ -279,9 +279,9 @@ function updateRmslist(forceDownload) {
 			data.forEach((rms) => {
 				let tr = $('<tr>')
 					.append($('<td class="text-left">').text(rms.callsign))
-					.append($('<td class="text-left">').text(rms.distance.toFixed(0) + " km"))
+					.append($('<td class="text-right">').text( ('\u00A0'.repeat(10) + (rms.distance.toFixed(0)) + ' km').substr(-10)  ))
 					.append($('<td class="text-left">').text(rms.modes))
-					.append($('<td class="text-right">').text(rms.dial.desc));
+					.append($('<td class="text-right">').text( ('\u00A0'.repeat(10) + rms.dial.desc).substr(-20) ));
 				tr.click((e) => {
 					tbody.find('.active').removeClass('active');
 					tr.addClass('active');

--- a/res/tmpl/index.html
+++ b/res/tmpl/index.html
@@ -227,7 +227,7 @@
               <div class="table-responsive table-fixed">
                 <table id="rmslist" class="table table-hover table-condensed">
                   <thead>
-                    <tr><th>target</th><th>distance</th><th>mode</th><th class="text-right">dial freq</th></tr>
+                    <tr><th>target</th><th class="text-right">distance</th><th>mode</th><th class="text-right">dial freq</th></tr>
                   </thead>
                   <tbody></tbody> <!-- This is populated by javascript -->
                 </table>


### PR DESCRIPTION
Use a lurid hack to fix this problem by right justifying the distance and frequency strings by prepending enough Unicode NO-BREAK SPACE characters \u00A0. The header-click sort function would normally trim leading spaces but is fooled by these non-spaces and doesn't trim them. Thus the resulting alpha sort also sorts numerically!