### PR TITLE
Allow Unsorted Connect Aliases

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -77,6 +77,13 @@ type Config struct {
 	// Any occurrence of the substring "{mycall}" will be replaced with user's callsign.
 	ConnectAliases map[string]string `json:"connect_aliases"`
 
+	UnsortedAliases [][]string `json:"unsorted_aliases"` 
+
+	AllAliases struct {
+		ConnectAliases *map[string]string `json:"connect_aliases"`
+		UnsortedAliases *[][]string `json:"unsorted_aliases"`
+	} `json:"all_aliases"`
+	
 	// Methods to listen for incoming P2P connections by default.
 	//
 	// Example: ["ax25", "winmor", "telnet", "ardop"]

--- a/config.go
+++ b/config.go
@@ -46,6 +46,9 @@ func LoadConfig(path string, fallback cfg.Config) (config cfg.Config, err error)
 		config.GPSd.Addr = config.GPSdAddrLegacy
 	}
 
+	config.AllAliases.ConnectAliases = &config.ConnectAliases
+	config.AllAliases.UnsortedAliases = &config.UnsortedAliases
+	
 	return config, nil
 }
 

--- a/connect.go
+++ b/connect.go
@@ -44,6 +44,12 @@ func Connect(connectStr string) (success bool) {
 		return false
 	} else if aliased, ok := config.ConnectAliases[connectStr]; ok {
 		return Connect(aliased)
+	} else {
+		for _, sub := range config.UnsortedAliases {
+			if sub[0] == connectStr {
+				return Connect(sub[1])
+			}
+		}
 	}
 
 	url, err := transport.ParseURL(connectStr)

--- a/http.go
+++ b/http.go
@@ -108,7 +108,7 @@ func rootHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func connectAliasesHandler(w http.ResponseWriter, r *http.Request) {
-	json.NewEncoder(w).Encode(config.ConnectAliases)
+	json.NewEncoder(w).Encode(config.AllAliases)
 }
 
 func readHandler(w http.ResponseWriter, r *http.Request) {

--- a/res/js/index.js
+++ b/res/js/index.js
@@ -303,12 +303,40 @@ function updateRmslist(forceDownload) {
 
 function updateConnectAliases() {
 	$.getJSON("/api/connect_aliases", function(data){
-		connectAliases = data;
+		allAliases = data;
+		connectAliases = allAliases["connect_aliases"]
+		unsortedAliases = allAliases["unsorted_aliases"]
+
 
 		var select = $('#aliasSelect');
-		Object.keys(data).forEach(function (key) {
-			select.append('<option>' + key + '</option>');
-		});
+
+		if (unsortedAliases) {
+			unsortedAliases.forEach((val, i, arr) => {
+				select.append('<option>' + val[0] + '</option>');
+			});
+		}
+
+		if (connectAliases) {
+			$.each(connectAliases, function (key, val) {
+				select.append('<option>' + key + '</option>');
+			});
+		}
+
+		// Now we add the unsorted entries to the map so they will
+		// be found when the key is selected.
+		if (unsortedAliases) {
+			unsortedAliases.forEach((val, i, arr) => {
+				connectAliases[val[0]] = val[1];
+			});
+		}
+
+		// $.each( data, function( key, val ) {
+		// 	select.append('<option>' + key + '</option>');
+		// });
+
+		// Object.keys(data).forEach(function (key) {
+		// 	select.append('<option>' + key + '</option>');
+		// });
 
 		select.change(function() {
 			$('#aliasSelect option:selected').each(function() {


### PR DESCRIPTION
Connect aliases are presented sorted into alphanumeric order, which is unnecessary and may be undesired. If the aliases are presented in the order they are entered in config.json then they can be in any order the user desires. This patch allows an unsorted ordering of connect aliases.

The re-ordering comes from storage in a Go map, which has no defined ordering. This patch uses  an array for the same purpose, which prevents re-ordering because arrays are inherently ordered.

In order to maintain backward compatibility in the format of config.json an optional new structure is allowed named unsorted_aliases of type [][]string. The first element of the subarray is the alias key and the second element is the URL. If entries are present in unsorted_aliases then they are presented in the aliases dropdown in unsorted order followed by any entries in connect_aliases sorted in alpha order.