### PR TITLE
Attempt to parse non-multipart form too

### DIFF
--- a/http.go
+++ b/http.go
@@ -64,7 +64,7 @@ type Notification struct {
 	Body  string `json:"body"`
 }
 
-type HttpError struct {
+type HTTPError struct {
 	error
 	StatusCode int
 }
@@ -217,7 +217,7 @@ func postOutboundMessageHandler(w http.ResponseWriter, r *http.Request) {
 			switch err := err.(type) {
 			case nil:
 				// No problem
-			case HttpError:
+			case HTTPError:
 				http.Error(w, err.Error(), err.StatusCode)
 			default:
 				http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -285,17 +285,17 @@ func attachFile(f *multipart.FileHeader, msg *fbb.Message) error {
 
 	if f.Filename == "" {
 		err := errors.New("missing attachment name")
-		return HttpError{err, http.StatusBadRequest}
+		return HTTPError{err, http.StatusBadRequest}
 	}
 	file, err := f.Open()
 	if err != nil {
-		return HttpError{err, http.StatusInternalServerError}
+		return HTTPError{err, http.StatusInternalServerError}
 	}
 
 	p, err := io.ReadAll(file)
 	file.Close()
 	if err != nil {
-		return HttpError{err, http.StatusInternalServerError}
+		return HTTPError{err, http.StatusInternalServerError}
 	}
 
 	if isImageMediaType(f.Filename, f.Header.Get("Content-Type")) {
@@ -313,7 +313,7 @@ func attachFile(f *multipart.FileHeader, msg *fbb.Message) error {
 	}
 
 	if err != nil {
-		return HttpError{err, http.StatusInternalServerError}
+		return HTTPError{err, http.StatusInternalServerError}
 	}
 	msg.AddFile(fbb.NewFile(f.Filename, p))
 	return nil

--- a/http.go
+++ b/http.go
@@ -195,8 +195,10 @@ func postMessageHandler(w http.ResponseWriter, r *http.Request) {
 func postOutboundMessageHandler(w http.ResponseWriter, r *http.Request) {
 	err := r.ParseMultipartForm(10 * (1024 ^ 2)) // 10Mb
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 	m := r.MultipartForm
 


### PR DESCRIPTION
The web frontend sends composed message with content type `multipart/form-data`, but some folks are now experimenting with scripting against the API. They ought to be able to send as `application/x-www-form-urlencoded` when their libraries use it.