### PR TITLE
Configure a default forms path

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -6,6 +6,8 @@ package cfg
 
 import (
 	"encoding/json"
+	"github.com/la5nta/wl2k-go/mailbox"
+	"path"
 	"strings"
 
 	"github.com/la5nta/wl2k-go/transport/ardop"
@@ -294,5 +296,10 @@ var DefaultConfig Config = Config{
 	HamlibRigs:     map[string]HamlibConfig{},
 
 	// Path to root of the unzipped Winlink Standard_Forms folder.
-	FormsPath: "",
+	FormsPath: path.Join(defaultAppDir(), "Standard_Forms"),
+}
+
+func defaultAppDir() string {
+	dir, _ := mailbox.DefaultAppDir()
+	return dir
 }

--- a/config.go
+++ b/config.go
@@ -47,9 +47,13 @@ func LoadConfig(path string, fallback cfg.Config) (config cfg.Config, err error)
 		config.GPSd.Addr = config.GPSdAddrLegacy
 	}
 
-	// clean up FormsPath (normalizes trailing slashes, and embedded '.' )
-	config.FormsPath = filepath.Clean(config.FormsPath)
-	config.FormsPath = strings.Replace(config.FormsPath, "\\", "/", -1)
+	if config.FormsPath == "" {
+		config.FormsPath = cfg.DefaultConfig.FormsPath
+	} else {
+		// clean up FormsPath (normalizes trailing slashes, and embedded '.' )
+		config.FormsPath = filepath.Clean(config.FormsPath)
+		config.FormsPath = strings.Replace(config.FormsPath, "\\", "/", -1)
+	}
 
 	return config, nil
 }

--- a/internal/forms/forms.go
+++ b/internal/forms/forms.go
@@ -108,6 +108,7 @@ var client = httpClient{http.Client{Timeout: 10 * time.Second}}
 
 // NewManager instantiates the forms manager
 func NewManager(conf Config) *Manager {
+	_ = os.MkdirAll(conf.FormsPath, 0755)
 	retval := &Manager{
 		config: conf,
 	}


### PR DESCRIPTION
This primes the user to run a forms update with zero configuration, but doesn't actually do it for them.  This could cause errors if they try to use forms before running the update. With some more work, we could make this more like the RMS list where the update happens proactively. For now, I think this is good enough.

Fixes #256