### PR TITLE
Some forms only have one HTML template

### DIFF
--- a/internal/forms/forms.go
+++ b/internal/forms/forms.go
@@ -652,11 +652,15 @@ func (m *Manager) buildFormFromTxt(txtPath string) (Form, error) {
 		case strings.HasPrefix(l, "Form:"):
 			trimmed := strings.TrimSpace(strings.TrimPrefix(l, "Form:"))
 			fileNames := strings.Split(trimmed, ",")
-			if fileNames != nil && len(fileNames) >= 2 {
+			if len(fileNames) >= 2 {
 				initial := strings.TrimSpace(fileNames[0])
 				viewer := strings.TrimSpace(fileNames[1])
 				retVal.InitialURI = path.Join(baseURI, initial)
 				retVal.ViewerURI = path.Join(baseURI, viewer)
+			} else {
+				view := strings.TrimSpace(fileNames[0])
+				retVal.InitialURI = path.Join(baseURI, view)
+				retVal.ViewerURI = path.Join(baseURI, view)
 			}
 		case strings.HasPrefix(l, "ReplyTemplate:"):
 			retVal.ReplyTxtFileURI = path.Join(baseURI, strings.TrimSpace(strings.TrimPrefix(l, "ReplyTemplate:")))

--- a/res/js/index.js
+++ b/res/js/index.js
@@ -352,7 +352,7 @@ function appendFormFolder(rootId, data) {
 			`);
 		data.folders.forEach(function (folder) {
 			if (folder.form_count > 0) {
-				var folderNameId = rootId + folder.name.replace( /\s/g, "_" );
+				var folderNameId = rootId + folder.name.replace( /\s/g, "_" ).replace(/&/g, "and");
 				var cardBodyId = folderNameId+"Body";
 				var card =
 				`


### PR DESCRIPTION
When a form .txt file only specifies one HTML template, it's supposed to be used for both compose and view.

Also fix a Javascript error. Now that "RADIOGRAM & RRI Forms" is coming through, we can't have ampersand in an HTML element ID.

Resolves #262 