### PR TITLE
Add http to log message

### DIFF
--- a/http.go
+++ b/http.go
@@ -72,7 +72,7 @@ type HTTPError struct {
 var websocketHub *WSHub
 
 func ListenAndServe(addr string) error {
-	log.Printf("Starting HTTP service (%s)...", addr)
+	log.Printf("Starting HTTP service (http://%s)...", addr)
 
 	if host, _, _ := net.SplitHostPort(addr); host == "" && config.GPSd.EnableHTTP {
 		// TODO: maybe make a popup showing the warning ont the web UI?


### PR DESCRIPTION
This very slight change makes the serving address a clickable link in many terminal emulators, which is a nice qualtiy-of-life improvement.