### PR TITLE
Fix some Go linter errors

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -245,7 +245,7 @@ type GPSdConfig struct {
 	Addr string `json:"addr"`
 }
 
-var DefaultConfig Config = Config{
+var DefaultConfig = Config{
 	MOTD:         []string{"Open source Winlink client - getpat.io"},
 	AuxAddrs:     []AuxAddr{},
 	ServiceCodes: []string{"PUBLIC"},

--- a/cli_composer.go
+++ b/cli_composer.go
@@ -117,11 +117,10 @@ func composeMessage(replyMsg *fbb.Message) {
 	if replyMsg != nil {
 		fmt.Fprintf(f, "--- %s %s wrote: ---\n", replyMsg.Date(), replyMsg.From().Addr)
 		body, _ := replyMsg.Body()
-		orig := ">" + strings.Replace(
+		orig := ">" + strings.ReplaceAll(
 			strings.TrimSpace(body),
 			"\n",
 			"\n>",
-			-1,
 		) + "\n"
 		f.Write([]byte(orig))
 		f.Sync()

--- a/config.go
+++ b/config.go
@@ -54,7 +54,7 @@ func LoadConfig(cfgPath string, fallback cfg.Config) (config cfg.Config, err err
 	} else {
 		// clean up FormsPath (normalizes trailing slashes, and embedded '.' )
 		config.FormsPath = filepath.Clean(config.FormsPath)
-		config.FormsPath = strings.Replace(config.FormsPath, "\\", "/", -1)
+		config.FormsPath = strings.ReplaceAll(config.FormsPath, "\\", "/")
 	}
 	debug.Printf("Forms dir is '%s'", config.FormsPath)
 
@@ -69,7 +69,7 @@ func replaceDeprecatedCMSHostname(path string, data []byte) ([]byte, error) {
 		return data, nil
 	}
 
-	data = bytes.Replace(data, []byte(o), []byte(n), -1)
+	data = bytes.ReplaceAll(data, []byte(o), []byte(n))
 
 	f, err := os.Open(path)
 	if err != nil {

--- a/connect.go
+++ b/connect.go
@@ -65,11 +65,11 @@ func Connect(connectStr string) (success bool) {
 			return
 		}
 	case "pactor":
-		pt_cmdinit := ""
+		ptCmdInit := ""
 		if val, ok := url.Params["init"]; ok {
-			pt_cmdinit = strings.Join(val, "\n")
+			ptCmdInit = strings.Join(val, "\n")
 		}
-		if err := initPactorModem(pt_cmdinit); err != nil {
+		if err := initPactorModem(ptCmdInit); err != nil {
 			log.Println(err)
 			return
 		}
@@ -83,9 +83,9 @@ func Connect(connectStr string) (success bool) {
 	// Set default host interface address
 	if url.Host == "" {
 		switch url.Scheme {
-		case "ax25":
+		case MethodAX25:
 			url.Host = config.AX25.Port
-		case "serial-tnc":
+		case MethodSerialTNC:
 			url.Host = config.SerialTNC.Path
 			if config.SerialTNC.Baudrate > 0 {
 				url.Params.Set("hbaud", fmt.Sprint(config.SerialTNC.Baudrate))
@@ -177,7 +177,7 @@ func qsy(method, addr string) (revert func(), err error) {
 	if err != nil {
 		return noop, err
 	} else if !ok {
-		return noop, fmt.Errorf("Hamlib rig '%s' not loaded.", rigName)
+		return noop, fmt.Errorf("hamlib rig '%s' not loaded", rigName)
 	}
 
 	log.Printf("QSY %s: %s", method, addr)
@@ -221,7 +221,7 @@ func initWinmorTNC() error {
 	var err error
 	wmTNC, err = winmor.Open(config.Winmor.Addr, fOptions.MyCall, config.Locator)
 	if err != nil {
-		return fmt.Errorf("WINMOR TNC initialization failed: %s", err)
+		return fmt.Errorf("WINMOR TNC initialization failed: %w", err)
 	}
 
 	if config.Winmor.DriveLevel != 0 {
@@ -244,7 +244,7 @@ func initWinmorTNC() error {
 
 	rig, ok := rigs[config.Winmor.Rig]
 	if !ok {
-		return fmt.Errorf("Unable to set PTT rig '%s': Not defined or not loaded.", config.Winmor.Rig)
+		return fmt.Errorf("unable to set PTT rig '%s': not defined or not loaded", config.Winmor.Rig)
 	}
 	wmTNC.SetPTT(rig)
 
@@ -263,17 +263,17 @@ func initArdopTNC() error {
 	var err error
 	adTNC, err = ardop.OpenTCP(config.Ardop.Addr, fOptions.MyCall, config.Locator)
 	if err != nil {
-		return fmt.Errorf("ARDOP TNC initialization failed: %s", err)
+		return fmt.Errorf("ARDOP TNC initialization failed: %w", err)
 	}
 
 	if !config.Ardop.ARQBandwidth.IsZero() {
 		if err := adTNC.SetARQBandwidth(config.Ardop.ARQBandwidth); err != nil {
-			return fmt.Errorf("Unable to set ARQ bandwidth for ardop TNC: %s", err)
+			return fmt.Errorf("unable to set ARQ bandwidth for ardop TNC: %w", err)
 		}
 	}
 
 	if err := adTNC.SetCWID(config.Ardop.CWID); err != nil {
-		return fmt.Errorf("Unable to configure CWID for ardop TNC: %s", err)
+		return fmt.Errorf("unable to configure CWID for ardop TNC: %w", err)
 	}
 
 	if v, err := adTNC.Version(); err != nil {
@@ -290,7 +290,7 @@ func initArdopTNC() error {
 
 	rig, ok := rigs[config.Ardop.Rig]
 	if !ok {
-		return fmt.Errorf("Unable to set PTT rig '%s': Not defined or not loaded.", config.Ardop.Rig)
+		return fmt.Errorf("unable to set PTT rig '%s': Not defined or not loaded", config.Ardop.Rig)
 	}
 
 	adTNC.SetPTT(rig)
@@ -304,7 +304,7 @@ func initPactorModem(cmdlineinit string) error {
 	var err error
 	pModem, err = pactor.OpenModem(config.Pactor.Path, config.Pactor.Baudrate, fOptions.MyCall, config.Pactor.InitScript, cmdlineinit)
 	if err != nil || pModem == nil {
-		return fmt.Errorf("Pactor initialization failed: %s", err)
+		return fmt.Errorf("pactor initialization failed: %w", err)
 	}
 
 	transport.RegisterDialer("pactor", pModem)

--- a/convert_image.go
+++ b/convert_image.go
@@ -7,13 +7,12 @@ package main
 import (
 	"bytes"
 	"image"
+	_ "image/gif"
 	"image/jpeg"
+	_ "image/png"
 	"mime"
 	"path"
 	"strings"
-
-	_ "image/gif"
-	_ "image/png"
 
 	"github.com/nfnt/resize"
 )

--- a/event_log.go
+++ b/event_log.go
@@ -17,7 +17,7 @@ type EventLogger struct {
 }
 
 func NewEventLogger(path string) (*EventLogger, error) {
-	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0666)
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o666)
 	return &EventLogger{file, json.NewEncoder(file)}, err
 }
 

--- a/exchange.go
+++ b/exchange.go
@@ -126,7 +126,7 @@ func sessionExchange(conn net.Conn, targetCall string, master bool) error {
 	stop := handleInterrupt()
 	defer close(stop)
 
-	startTs := time.Now()
+	start := time.Now()
 
 	stats, err := session.Exchange(conn)
 	if fbb.IsLoginFailure(err) {
@@ -150,7 +150,7 @@ func sessionExchange(conn net.Conn, targetCall string, master bool) error {
 		"local_addr":          conn.LocalAddr().String(),
 		"sent":                stats.Sent,
 		"received":            stats.Received,
-		"start":               startTs.Unix(),
+		"start":               start.Unix(),
 		"end":                 time.Now().Unix(),
 		"success":             err == nil,
 	}

--- a/flags.go
+++ b/flags.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-var ErrNoCmd = fmt.Errorf("No CMD")
+var ErrNoCmd = fmt.Errorf("no cmd")
 
 type Command struct {
 	Str        string

--- a/freq.go
+++ b/freq.go
@@ -103,10 +103,10 @@ func VFOForTransport(transport string) (vfo hamlib.VFO, rigName string, ok bool,
 	case MethodPactor:
 		rig = config.Pactor.Rig
 	default:
-		return vfo, "", false, fmt.Errorf("Not supported with transport '%s'", transport)
+		return vfo, "", false, fmt.Errorf("not supported with transport '%s'", transport)
 	}
 	if rig == "" {
-		return vfo, "", false, fmt.Errorf("Missing rig reference in config section for %s", transport)
+		return vfo, "", false, fmt.Errorf("missing rig reference in config section for %s", transport)
 	}
 	vfo, ok = rigs[rig]
 	return vfo, rig, ok, nil
@@ -141,7 +141,7 @@ func freq(param string) {
 func setFreq(rig hamlib.VFO, freq string) (newFreq, oldFreq int, err error) {
 	oldFreq, err = rig.GetFreq()
 	if err != nil {
-		return 0, 0, fmt.Errorf("Unable to get rig frequency: %s", err)
+		return 0, 0, fmt.Errorf("unable to get rig frequency: %w", err)
 	}
 
 	f, err := strconv.ParseFloat(freq, 64)

--- a/http.go
+++ b/http.go
@@ -39,6 +39,7 @@ import (
 
 //go:embed web/res/**
 var embeddedFS embed.FS
+
 var staticContent fs.FS
 
 // Status represents a status report as sent to the Web GUI
@@ -746,8 +747,8 @@ func blockquoteDepth(str string) (n int) {
 
 // htmlEncode encodes html characters
 func htmlEncode(str string) string {
-	str = strings.Replace(str, ">", "&gt;", -1)
-	str = strings.Replace(str, "<", "&lt;", -1)
+	str = strings.ReplaceAll(str, ">", "&gt;")
+	str = strings.ReplaceAll(str, "<", "&lt;")
 	return str
 }
 

--- a/internal/cmsapi/api.go
+++ b/internal/cmsapi/api.go
@@ -22,7 +22,7 @@ const (
 	PathGatewayStatus = "/gateway/status.json"
 	PathAccountExists = "/account/exists"
 
-	// Issued December 2017 by the WDT for use with Pat
+	// AccessKey issued December 2017 by the WDT for use with Pat
 	AccessKey = "1880278F11684B358F36845615BD039A"
 )
 
@@ -37,8 +37,8 @@ func (v VersionAdd) Post() error {
 	b, _ := json.Marshal(v)
 	buf := bytes.NewBuffer(b)
 
-	url := RootURL + PathVersionAdd + "?key=" + AccessKey
-	req, _ := http.NewRequest("POST", url, buf)
+	versionURL := RootURL + PathVersionAdd + "?key=" + AccessKey
+	req, _ := http.NewRequest("POST", versionURL, buf)
 	req.Header.Set("content-type", "application/json")
 	req.Header.Set("accept", "application/json")
 
@@ -61,8 +61,8 @@ func (v VersionAdd) Post() error {
 }
 
 func AccountExists(callsign string) (bool, error) {
-	url := RootURL + PathAccountExists + "?key=" + AccessKey + "&callsign=" + url.QueryEscape(callsign)
-	req, _ := http.NewRequest("GET", url, nil)
+	accountURL := RootURL + PathAccountExists + "?key=" + AccessKey + "&callsign=" + url.QueryEscape(callsign)
+	req, _ := http.NewRequest("GET", accountURL, nil)
 	req.Header.Set("Accept", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -134,7 +134,7 @@ func GetGatewayStatus(mode string, historyHours int, serviceCodes ...string) (io
 	case err != nil:
 		return nil, err
 	case resp.StatusCode != http.StatusOK:
-		return nil, fmt.Errorf("Unexpected http status '%s'.", resp.Status)
+		return nil, fmt.Errorf("unexpected http status '%v'", resp.Status)
 	}
 
 	return resp.Body, err

--- a/internal/gpsd/gpsd.go
+++ b/internal/gpsd/gpsd.go
@@ -20,9 +20,9 @@ const (
 	Mode3D
 )
 
-var ErrUnsupportedProtocolVersion = errors.New("Unsupported protocol version")
+var ErrUnsupportedProtocolVersion = errors.New("unsupported protocol version")
 
-// Objects implementing the Positioner interface provides geographic positioning data.
+// Positioner implementations provide geographic positioning data.
 //
 // This is particularly useful for testing if an object returned by Next can be used to determine the device position.
 type Positioner interface {
@@ -30,7 +30,7 @@ type Positioner interface {
 	HasFix() bool
 }
 
-// Position holds geopgraphic positioning data.
+// Position holds geographic positioning data.
 type Position struct {
 	Lat, Lon float64   // Latitude/longitude in degrees. +/- signifies north/south.
 	Alt      float64   // Altitude in meters.
@@ -65,7 +65,7 @@ func Dial(addr string) (*Conn, error) {
 	err = json.NewDecoder(c.rd).Decode(&c.Version)
 	if err != nil || c.Version.Release == "" {
 		tcpConn.Close()
-		return nil, errors.New("Unexpected server response")
+		return nil, errors.New("unexpected server response")
 	}
 
 	if c.Version.ProtoMajor < 3 {
@@ -158,8 +158,8 @@ func (c *Conn) next() (interface{}, error) {
 }
 
 var (
-	ErrTimeout          = errors.New("Timeout")
-	ErrWatchModeEnabled = errors.New("Operation not available while in watch mode")
+	ErrTimeout          = errors.New("timeout")
+	ErrWatchModeEnabled = errors.New("operation not available while in watch mode")
 )
 
 // NextPos returns the next reported position.
@@ -179,7 +179,8 @@ func (c *Conn) NextPosTimeout(timeout time.Duration) (Position, error) {
 
 	for {
 		obj, err := c.Next()
-		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		var netErr net.Error
+		if ok := errors.As(err, &netErr); ok && netErr.Timeout() {
 			return Position{}, ErrTimeout
 		} else if err != nil {
 			return Position{}, err
@@ -229,7 +230,7 @@ func (c *Conn) send(s string, params ...interface{}) error {
 }
 
 func errUnexpected(err error) error {
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		err = io.ErrUnexpectedEOF
 	}
 	return err

--- a/internal/gpsd/objects.go
+++ b/internal/gpsd/objects.go
@@ -79,7 +79,7 @@ type Device struct {
 	Parity   string `json:"parity"`
 	StopBits int    `json:"stopbits"`
 
-	//Activated time.Time `json:"activated,omitempty"` (Must parse as fractional epoch time)
+	// Activated time.Time `json:"activated,omitempty"` (Must parse as fractional epoch time)
 }
 
 type watch struct {

--- a/internal/osutil/rlimit_unix.go
+++ b/internal/osutil/rlimit_unix.go
@@ -11,7 +11,7 @@ import (
 func RaiseOpenFileLimit(max uint64) error {
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
-		return fmt.Errorf("Could not get current limit: %v", err)
+		return fmt.Errorf("could not get current limit: %w", err)
 	}
 	if limit.Cur >= limit.Max || limit.Cur >= max {
 		return nil

--- a/main.go
+++ b/main.go
@@ -287,7 +287,7 @@ func main() {
 
 	// Replace placeholders in connect aliases
 	for k, v := range config.ConnectAliases {
-		config.ConnectAliases[k] = strings.Replace(v, cfg.PlaceholderMycall, fOptions.MyCall, -1)
+		config.ConnectAliases[k] = strings.ReplaceAll(v, cfg.PlaceholderMycall, fOptions.MyCall)
 	}
 
 	if fOptions.Listen == "" && len(config.Listen) > 0 {
@@ -462,20 +462,20 @@ func loadMBox() {
 func loadHamlibRigs() map[string]hamlib.VFO {
 	rigs := make(map[string]hamlib.VFO, len(config.HamlibRigs))
 
-	for name, cfg := range config.HamlibRigs {
-		if cfg.Address == "" {
+	for name, conf := range config.HamlibRigs {
+		if conf.Address == "" {
 			log.Printf("Missing address-field for rig '%s', skipping.", name)
 			continue
 		}
 
-		rig, err := hamlib.Open(cfg.Network, cfg.Address)
+		rig, err := hamlib.Open(conf.Network, conf.Address)
 		if err != nil {
 			log.Printf("Initialization hamlib rig %s failed: %s.", name, err)
 			continue
 		}
 
 		var vfo hamlib.VFO
-		switch strings.ToUpper(cfg.VFO) {
+		switch strings.ToUpper(conf.VFO) {
 		case "A", "VFOA":
 			vfo, err = rig.VFOA()
 		case "B", "VFOB":
@@ -483,7 +483,7 @@ func loadHamlibRigs() map[string]hamlib.VFO {
 		case "":
 			vfo = rig.CurrentVFO()
 		default:
-			log.Printf("Cannot load rig '%s': Unrecognized VFO identifier '%s'", name, cfg.VFO)
+			log.Printf("Cannot load rig '%s': Unrecognized VFO identifier '%s'", name, conf.VFO)
 			continue
 		}
 

--- a/prompt_hub.go
+++ b/prompt_hub.go
@@ -36,13 +36,13 @@ func NewPromptHub() *PromptHub { p := new(PromptHub); go p.loop(); return p }
 func (p *PromptHub) OmitTerminal(t bool) { p.omitTerminal = t }
 
 func (p *PromptHub) loop() {
-	p.c = make(chan *Prompt, 0)
-	p.rc = make(chan PromptResponse, 0)
+	p.c = make(chan *Prompt)
+	p.rc = make(chan PromptResponse)
 	for prompt := range p.c {
 		timeout := time.After(prompt.Deadline.Sub(time.Now()))
 		select {
 		case <-timeout:
-			prompt.resp <- PromptResponse{ID: prompt.ID, Err: fmt.Errorf("Deadline reached")}
+			prompt.resp <- PromptResponse{ID: prompt.ID, Err: fmt.Errorf("deadline reached")}
 			close(prompt.cancel)
 		case resp := <-p.rc:
 			if resp.ID != prompt.ID {

--- a/read.go
+++ b/read.go
@@ -112,8 +112,8 @@ func printMsg(w io.Writer, msg *fbb.Message) {
 }
 
 func printMailboxes(w io.Writer) {
-	for i, mailbox := range mailboxes {
-		fmt.Fprintf(w, "%d:%s\t", i, mailbox)
+	for i, mbox := range mailboxes {
+		fmt.Fprintf(w, "%d:%s\t", i, mbox)
 	}
 }
 
@@ -125,7 +125,7 @@ func printMessages(w io.Writer, msgs []*fbb.Message) {
 			to = msg.To()[0].Addr
 		}
 		if len(msg.To()) > 1 {
-			to = to + ", ..."
+			to += ", ..."
 		}
 
 		var flags string

--- a/rmslist.go
+++ b/rmslist.go
@@ -137,7 +137,7 @@ func ReadRMSList(forceDownload bool, filterFn func(rms RMS) (keep bool)) ([]RMS,
 		return nil, err
 	}
 
-	slice := []RMS{}
+	var slice []RMS
 	for _, gw := range status.Gateways {
 		for _, channel := range gw.Channels {
 			r := RMS{
@@ -147,8 +147,8 @@ func ReadRMSList(forceDownload bool, filterFn func(rms RMS) (keep bool)) ([]RMS,
 				Freq:       Frequency(channel.Frequency),
 				Dial:       Frequency(channel.Frequency).Dial(channel.SupportedModes),
 			}
-			if url := toURL(channel, gw.Callsign); url != nil {
-				r.URL = &JSONURL{*url}
+			if chURL := toURL(channel, gw.Callsign); chURL != nil {
+				r.URL = &JSONURL{*chURL}
 			}
 			hasLocator := me != maidenhead.Point{}
 			if them, err := maidenhead.ParseLocator(channel.Gridsquare); err == nil && hasLocator {
@@ -166,8 +166,8 @@ func ReadRMSList(forceDownload bool, filterFn func(rms RMS) (keep bool)) ([]RMS,
 
 func toURL(gc cmsapi.GatewayChannel, targetcall string) *url.URL {
 	freq := Frequency(gc.Frequency).Dial(gc.SupportedModes)
-	url, _ := url.Parse(fmt.Sprintf("%s:///%s?freq=%v", toTransport(gc), targetcall, freq.KHz()))
-	return url
+	chURL, _ := url.Parse(fmt.Sprintf("%s:///%s?freq=%v", toTransport(gc), targetcall, freq.KHz()))
+	return chURL
 }
 
 var transports = []string{"winmor", "ax25", "pactor", "ardop"}

--- a/schedule.go
+++ b/schedule.go
@@ -5,9 +5,10 @@
 package main
 
 import (
-	"github.com/gorhill/cronexpr"
 	"log"
 	"time"
+
+	"github.com/gorhill/cronexpr"
 )
 
 type Job struct {

--- a/usage.go
+++ b/usage.go
@@ -45,11 +45,9 @@ params:
 `
 )
 
-var (
-	ExamplePosition = `
+var ExamplePosition = `
   position -c "QRV 145.500MHz"       Send position and comment with coordinates retrieved from GPSd.
   position --latlon 59.123,005.123   Send position 59.123N 005.123E.
   position --latlon 40.704,-73.945   Send position 40.704N 073.945W.
   position --latlon -10.123,-60.123  Send position 10.123S 060.123W.
 `
-)


### PR DESCRIPTION
* `Replace(..., -1)` with `ReplaceAll()`
* Variable names hiding packages
* Error messages start with lowercase and no end punctuation
* Don't `defer` in a loop
* Etc.