### PR TITLE
Add support for scriptable message composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Copyright (c) 2020 Martin Hebnes Pedersen LA5NTA
 * LA4TTA - Erlend Grimseid
 * LA5NTA - Martin Hebnes Pedersen
 * W6IPA  - JC Martin
+* WY2K - Benjamin Seidenberg
 * VE7GNU - Doug Collinge
 
 ## Thanks to

--- a/main.go
+++ b/main.go
@@ -73,11 +73,19 @@ var commands = []Command{
 		LongLived:  true,
 	},
 	{
-		Str:  "compose",
-		Desc: "Compose a new message.",
-		HandleFunc: func(args []string) {
-			composeMessage(nil)
+		Str: "compose",
+		Desc: "Compose a new message.\n" +
+			"\tIf no options are passed, composes interactively.\n" +
+			"\tIf options are passed, reads message from stdin similar to mail(1).",
+		Usage: "[options]",
+		Options: map[string]string{
+			"--callsign, -r":    "Callsign to send from. Default reads from config",
+			"--subject, -s":     "Subject",
+			"--attachment , -a": "Attachment path (may be repeated)",
+			"--cc, -c":          "CC Address(es) (may be repeated)",
+			"":                  "Recipient address (may be repeated)",
 		},
+		HandleFunc: composeMessage,
 	},
 	{
 		Str:  "read",

--- a/read.go
+++ b/read.go
@@ -76,7 +76,7 @@ func readMail() {
 			fmt.Fprintf(w, "Reply (ctrl+c to quit) [y/N]: ")
 			ans := readLine()
 			if strings.EqualFold(ans, "y") {
-				composeMessage(msgs[msgIdx])
+				composeReplyMessage(msgs[msgIdx])
 			}
 		}
 	}


### PR DESCRIPTION
Addresses https://github.com/la5nta/pat/issues/

This commit adds support for non-interactive message sending from the command line, in order to support scriptable interactions.
    
To do this, we fork the compose path into 3:
* Interactive (existing)
* Non-Interactive (based on command-line arguments and stdin)
* Reply (synonym for interactive)

_**NOTE:** This is quite literally the first golang code I've written, as well as my first commit to your code base, so please take extra care in the review, and don't spare any feedback - I genuinely want as much as possible to ensure it's correct and idiomatic._