### PR TITLE
Add `env` command

### DIFF
--- a/env.go
+++ b/env.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+
+	"github.com/la5nta/pat/internal/buildinfo"
+)
+
+func envHandle(_ []string) {
+	writeEnvAll(os.Stdout)
+}
+
+func writeEnvAll(w io.Writer) {
+	writeEnv(w, "PAT_MYCALL", fOptions.MyCall)
+	writeEnv(w, "PAT_LOCATOR", config.Locator)
+	writeEnv(w, "PAT_VERSION", buildinfo.Version)
+	writeEnv(w, "PAT_ARCH", runtime.GOARCH)
+	writeEnv(w, "PAT_OS", runtime.GOOS)
+	writeEnv(w, "PAT_MAILBOX_PATH", fOptions.MailboxPath)
+	writeEnv(w, "PAT_CONFIG_PATH", fOptions.ConfigPath)
+	writeEnv(w, "PAT_LOG_PATH", fOptions.LogPath)
+	writeEnv(w, "PAT_EVENTLOG_PATH", fOptions.EventLogPath)
+	writeEnv(w, "PAT_FORMS_PATH", fOptions.FormsPath)
+	writeEnv(w, "PAT_DEBUG", os.Getenv("PAT_DEBUG"))
+	writeEnv(w, "ARDOP_DEBUG", os.Getenv("ARDOP_DEBUG"))
+	writeEnv(w, "WINMOR_DEBUG", os.Getenv("WINMOR_DEBUG"))
+	writeEnv(w, "PACTOR_DEBUG", os.Getenv("PACTOR_DEBUG"))
+}
+
+func writeEnv(w io.Writer, k, v string) {
+	fmt.Fprintf(w, "%s=\"%s\"\n", k, v)
+}

--- a/main.go
+++ b/main.go
@@ -142,10 +142,15 @@ var commands = []Command{
 	},
 	{
 		Str:  "version",
-		Desc: "Print the application version",
+		Desc: "Print the application version.",
 		HandleFunc: func(args []string) {
 			fmt.Printf("%s %s\n", buildinfo.AppName, buildinfo.VersionString())
 		},
+	},
+	{
+		Str:        "env",
+		Desc:       "List environment variables.",
+		HandleFunc: envHandle,
 	},
 	{
 		Str:  "help",


### PR DESCRIPTION
This adds a new CLI command for printing useful env variables.
    
This should be particularly useful when scriping against Pat. It also serves as a sort of documentation of various environment variables that effects Pat.