### PR TITLE
Fix typing errors in d/changelog and comments

### DIFF
--- a/cli_composer.go
+++ b/cli_composer.go
@@ -175,7 +175,7 @@ func noninteractiveComposeMessage(subject string, attachments []string,
 	postMessage(msg)
 }
 
-// This is currently an alias for interactiveComposeMessage but keeping as a seperate
+// This is currently an alias for interactiveComposeMessage but keeping as a separate
 // call path for the future
 func composeReplyMessage(replyMsg *fbb.Message) {
 	interactiveComposeMessage(replyMsg)

--- a/debian/changelog
+++ b/debian/changelog
@@ -32,7 +32,7 @@ pat (0.11.0) stable; urgency=medium
   * Add support for individual passords for auxiliary addresses
   * Add ability to abort ongoing dialing/connection in Web GUI
   * Add systemd unit file for rigctld
-  * Improve version reporing to Winlink API
+  * Improve version reporting to Winlink API
   * Improve websocket handling
   * Improve visibility of QSY errors in Web GUI
   * Improve 'reply' and 'forward' functionality in Web GUI
@@ -175,7 +175,7 @@ pat (0.2.1) stable; urgency=medium
 pat (0.2.0) stable; urgency=medium
 
   * Support Radio only - Winlink Hybrid Network (https://github.com/la5nta/pat/issues/44)
-  * Swich to Go port of lzhuf (https://github.com/la5nta/pat/issues/50)
+  * Switch to Go port of lzhuf (https://github.com/la5nta/pat/issues/50)
   * Linux ax25 scripts: Add method for custom TNC initialization (https://github.com/la5nta/pat/issues/53)
   * Fix ardop PTT rigcontrol (https://github.com/la5nta/pat/issues/58)
   * Minor bug fixes and improvements in the web GUI

--- a/main.go
+++ b/main.go
@@ -361,7 +361,7 @@ func main() {
 }
 
 func maybeUpdateFormsDir(args []string) {
-	// Backward compatability for config file forms_path
+	// Backward compatibility for config file forms_path
 	formsFlagExplicitlyUsed := false
 	for i := 0; i < len(args); i++ {
 		if strings.HasPrefix(args[i], "--forms") {


### PR DESCRIPTION
Fix spelling erors found with:
codespell --skip web,*.rtf --ignore-words-list ans --write-changes