### PR TITLE
Add arm64 to list of supported deb architectures

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 7.0.50~), golang (>= 2:1.16), libax25, libax25-dev
 Standards-Version: 3.9.1
 
 Package: pat
-Architecture: amd64 i386 armhf
+Architecture: amd64 i386 armhf arm64
 Conflicts: wl2k-go, dist
 Replaces: wl2k-go
 Recommends: libhamlib-utils (>= 1.2), ax25-tools, gpsd (>= 2.90)


### PR DESCRIPTION
Ref #321