### PR TITLE
Graceful shutdown through context cancellation

### DIFF
--- a/cli_composer.go
+++ b/cli_composer.go
@@ -8,6 +8,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -102,7 +103,7 @@ func composeMessageHeader(replyMsg *fbb.Message) *fbb.Message {
 	return msg
 }
 
-func composeMessage(args []string) {
+func composeMessage(ctx context.Context, args []string) {
 	set := pflag.NewFlagSet("compose", pflag.ExitOnError)
 	// From default is --mycall but it can be overriden with -r
 	from := set.StringP("from", "r", fOptions.MyCall, "")
@@ -295,7 +296,7 @@ func readLine() string {
 	return strings.TrimSpace(str)
 }
 
-func composeFormReport(args []string) {
+func composeFormReport(ctx context.Context, args []string) {
 	var tmplPathArg string
 
 	set := pflag.NewFlagSet("form", pflag.ExitOnError)

--- a/connect.go
+++ b/connect.go
@@ -140,9 +140,6 @@ func Connect(connectStr string) (success bool) {
 		waitBusy(wmTNC)
 	}
 
-	// Catch interrupts (signals) while dialing, so users can abort ardop/winmor connects.
-	doneHandleInterrupt := handleInterrupt()
-
 	// Signal web gui that we are dialing a connection
 	dialing = url
 	websocketHub.UpdateStatus()
@@ -153,8 +150,6 @@ func Connect(connectStr string) (success bool) {
 	// Signal web gui that we are no longer dialing
 	dialing = nil
 	websocketHub.UpdateStatus()
-
-	close(doneHandleInterrupt)
 
 	eventLog.LogConn("connect "+connectStr, currFreq, conn, err)
 

--- a/env.go
+++ b/env.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -9,7 +10,7 @@ import (
 	"github.com/la5nta/pat/internal/buildinfo"
 )
 
-func envHandle(_ []string) {
+func envHandle(_ context.Context, _ []string) {
 	writeEnvAll(os.Stdout)
 }
 

--- a/flags.go
+++ b/flags.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -18,7 +19,7 @@ type Command struct {
 	Str        string
 	Aliases    []string
 	Desc       string
-	HandleFunc func(args []string)
+	HandleFunc func(ctx context.Context, args []string)
 	Usage      string
 	Options    map[string]string
 	Example    string


### PR DESCRIPTION
By doing graceful shutdown, we're able to properly close all of the open resources such as modem connections and ongoing sessions.

This will allow transport drivers controlling stateful TNCs (e.g. ptc-go) to recover the initial TNC state before termination.

Resolves #314.

------

This approach uses Go's [context package](https://pkg.go.dev/context). Here are some posts explaining the concept:
- http://p.agnihotry.com/post/understanding_the_context_package_in_golang/
- https://go.dev/blog/context