### PR TITLE
Implement missing form template GPS-related insertion tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Copyright (c) 2020 Martin Hebnes Pedersen LA5NTA
 * LA3QMA - Kai Günter Brandt
 * LA4TTA - Erlend Grimseid
 * LA5NTA - Martin Hebnes Pedersen
+* N2YGK - Alan Crosswell
 * VE7GNU - Doug Collinge
 * W6IPA  - JC Martin
 * WY2K - Benjamin Seidenberg

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -226,11 +226,15 @@ type GPSdConfig struct {
 	// Caution: Your GPS position will be accessible to any network device able to access Pat's HTTP interface.
 	EnableHTTP bool `json:"enable_http"`
 
-	// Use server time instead of timestamp provided by GPSd (e.g for older GPS
-	// device with week roll-over issue)
+	// Allow Winlink forms to use GPSd for aquiring your position.
+	//
+	// Caution: Your current GPS position will be automatically injected, without your explicit consent, into forms requesting such information.
+	AllowForms bool `json:"allow_forms"`
+
+	// Use server time instead of timestamp provided by GPSd (e.g for older GPS device with week roll-over issue).
 	UseServerTime bool `json:"use_server_time"`
 
-	// Address and port of GPSd server (e.g. localhost:2947)
+	// Address and port of GPSd server (e.g. localhost:2947).
 	Addr string `json:"addr"`
 }
 
@@ -272,6 +276,7 @@ var DefaultConfig = Config{
 	},
 	GPSd: GPSdConfig{
 		EnableHTTP:    false, // Default to false to help protect privacy of unknowing users (see github.com//issues/146)
+		AllowForms:    false, // Default to false to help protect location privacy of unknowing users
 		UseServerTime: false,
 		Addr:          "localhost:2947", // Default listen address for GPSd
 	},

--- a/main.go
+++ b/main.go
@@ -346,6 +346,7 @@ func main() {
 		AppVersion: buildinfo.VersionStringShort(),
 		UserAgent:  buildinfo.UserAgent(),
 		LineReader: readLine,
+		GPSd:       config.GPSd,
 	})
 
 	// Make sure we clean up on exit, closing any open resources etc.


### PR DESCRIPTION
Fixes: #328 

Implements several missing insertion tags for form templates (some of which are not documented other than by reading the HTML):

- {GPS} -  degrees and decimal minutes with Northing and Easting: 46-22.77N 121-35.01W
- {GPS_DECIMAL} - decimal degrees with Northing and Easting: 46.3795N 121.5835W
- {GPS_SIGNED_DECIMAL} - signed decimal degrees: 41.1234 -73.4567
- {Latitude} and {latitude} - signed decimal latitude degrees: 41.1234
- {Longitude} and {longitude} - signed decimal longitude degrees: -73.4567
- {GridSquare} - maidenhead grid square locator: FN31cd
- {GPSValid} - "YES " or "NO " to indicate GPS position is valid

Some of these values are substituted in forms but not used (like GridSquare).
