### PR TITLE
If the developer has Node Version Manager, use it

### DIFF
--- a/make.bash
+++ b/make.bash
@@ -22,6 +22,10 @@ function install_libax25 {
 }
 function build_web {
 	cd web
+	if [ -d $NVM_DIR ]; then
+	  source $NVM_DIR/nvm.sh
+	  nvm use
+	fi
 	npm install
 	npm run production
 }


### PR DESCRIPTION
For some reason, we're stuck on a slightly older (but still supported) version of node 14/npm 6. If we try to run npm commands with the latest LTS node 16/npm 8, `npm install` fails. There's already an `.nvmrc` file in the web directory to signal which version of node is needed, but this causes the `make.bash` file to make sure that version is actually used. Does nothing if the developer does not have nvm installed, they'll just get the warning about "unsupported engine."