### PR TITLE
Make manpage entries point to `pat env`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ To make the process as seamless as possible, we ask for the following:
       - Run `go fmt`
       - Consider squashing your commits into a single commit. `git rebase -i`. It's okay to force update your pull request.
       - **Write a good commit message.** This [blog article](http://chris.beams.io/posts/git-commit/) is a good resource for learning how to write good commit messages, the most important part being that each commit message should have a title/subject in imperative mood starting with a capital letter and no trailing period: *"Return error on wrong use of the Paginator"*, **NOT** *"returning some error."* Also, if your commit references one or more GitHub issues, always end your commit message body with *See #1234* or *Fixes #1234*. Replace *1234* with the GitHub issue ID. The last example will close the issue when the commit is merged into *master*.
-      - Make sure `go test ./...` passes, and `go build` completes. Our [Travis CI loop](https://travis-ci.org/la5nta/pat) (Linux and OS&nbsp;X) will catch most things that are missing.
+      - Make sure `go test ./...` passes, and `go build` completes. Our [Travis CI loop](https://app.travis-ci.com/github/la5nta/pat) (Linux and OS&nbsp;X) will catch most things that are missing.
 
 ## The release process
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Copyright (c) 2020 Martin Hebnes Pedersen LA5NTA
 
 * DL1THM - Torsten Harenberg
 * HB9GPA - Matthias Renner
+* K0RET - Ryan Turner
 * K0SWE - Chris Keller
 * KD8DRX - Will Davidson
 * KE8HMG - Andrew Huebner

--- a/man/pat-configure.1
+++ b/man/pat-configure.1
@@ -3,7 +3,7 @@
 pat configure \- opens Pat's configuration file using the system default editor
 .SH Configuration
 .SS Main Configuration
-The default configuration file for pat is \fI~/.wl2k/config.json\fP
+The current configuration file is located in the \fIPAT_CONFIG_PATH\fP returned from \fIpat env\fP
 .sp 1
 To get "on the air" you'll first have to set up your callsign, maidenhead locator, and secure login credentials. Look for the attributes \fImycall\fP, \fIlocator\fP and \fIsecure_login_password\fP and set them appropriately.
 .sp 1

--- a/man/pat.1
+++ b/man/pat.1
@@ -43,10 +43,10 @@ Print detailed help for a given command.
 .SS Options
 .TP
 \fR--config string\fP
-Path to config file (default "/home/USER/.wl2k/config.json").
+Path to config file (located in the \fIPAT_CONFIG_PATH\fP returned from \fIpat env\fP).
 .TP
 \fR--event-log string\fP
-Path to event log file (default "/home/USER/.wl2k/config.json").
+Path to event log file (located in the \fIPAT_CONFIG_PATH\fP returned from \fIpat env\fP).
 .TP
 \fR--ignore-busy\fP
 Don't wait for clear channel before connevting to a node.
@@ -55,10 +55,10 @@ Don't wait for clear channel before connevting to a node.
 Comma-separated list of methods to listen on (e.g. ardop,telnet,ax25).
 .TP
 \fR--log string\fP
-Path to log file. The file is truncated on each startup (default "/home/USER/.wl2k/pat.log").
+Path to log file. The file is truncated on each startup (located in the \fIPAT_LOG_PATH\fP returned from \fIpat env\fP).
 .TP
 \fR--mbox string\fP
-Path to mailbox directory (default "/home/USER/.wl2k/mailbox").
+Path to mailbox directory (located in the \fIPAT_MAILBOX_PATH\fP returned from \fIpat env\fP).
 .TP
 \fR--mycall string\fP
 Your callsing (winlink user).


### PR DESCRIPTION
e94f05f37cc5866f66e88d177dc39b2b5dc579a0 introduced a change, but the docs got missed. This follows up on that to fix the manpage documentation. As a chore at the same time, this fixes dev doc references to old travis-ci paths and adds the committer as a contributor.

Closes !326