### PR TITLE
Reverse proxy for webpack-dev-server

### DIFF
--- a/env.go
+++ b/env.go
@@ -26,6 +26,7 @@ func writeEnvAll(w io.Writer) {
 	writeEnv(w, "PAT_EVENTLOG_PATH", fOptions.EventLogPath)
 	writeEnv(w, "PAT_FORMS_PATH", fOptions.FormsPath)
 	writeEnv(w, "PAT_DEBUG", os.Getenv("PAT_DEBUG"))
+	writeEnv(w, "PAT_WEB_DEV_ADDR", os.Getenv("PAT_WEB_DEV_ADDR"))
 	writeEnv(w, "ARDOP_DEBUG", os.Getenv("ARDOP_DEBUG"))
 	writeEnv(w, "PACTOR_DEBUG", os.Getenv("PACTOR_DEBUG"))
 }

--- a/web/package.json
+++ b/web/package.json
@@ -33,7 +33,7 @@
     "format": "prettier -w **",
     "production": "webpack --mode=production --progress --hide-modules --devtool=source-maps",
     "postinstall": "rm -rf node_modules/bootstrap-tokenfield/node_modules",
-    "start": "webpack-dev-server --open --mode=development",
+    "start": "webpack-dev-server --mode=development --port=8081",
     "watch": "webpack --mode=development --watch"
   },
   "dependencies": {


### PR DESCRIPTION
Add ability to proxy `/dist/...` requests to webpack-dev-server for web development convenience.

Also fetches the index.html (`/ui`) template from the same host.

```
PAT_WEB_DEV_ADDR=http://localhost:8081 go run . http &
npm start
```

Should do the trick 🙂 