### PR TITLE
forms: fix to and cc fields

### DIFF
--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -238,6 +238,12 @@ function pollFormData() {
 function writeFormDataToComposer(data) {
   if (data.target_form) {
     $('#msg_body').val(data.msg_body);
+    if (data.msg_to) {
+      $('#msg_to').tokenfield('setTokens', data.msg_to.split(";").filter(Boolean));
+    }
+    if (data.msg_cc) {
+      $('#msg_cc').tokenfield('setTokens', data.msg_cc.split(";").filter(Boolean));
+    }
     if (data.msg_subject) {
       // in case of composing a form-based reply we keep the 'Re: ...' subject line
       $('#msg_subject').val(data.msg_subject);

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -239,10 +239,10 @@ function writeFormDataToComposer(data) {
   if (data.target_form) {
     $('#msg_body').val(data.msg_body);
     if (data.msg_to) {
-      $('#msg_to').tokenfield('setTokens', data.msg_to.split(";").filter(Boolean));
+      $('#msg_to').tokenfield('setTokens', data.msg_to.split(/[ ;,]/).filter(Boolean));
     }
     if (data.msg_cc) {
-      $('#msg_cc').tokenfield('setTokens', data.msg_cc.split(";").filter(Boolean));
+      $('#msg_cc').tokenfield('setTokens', data.msg_cc.split(/[ ;,]/).filter(Boolean));
     }
     if (data.msg_subject) {
       // in case of composing a form-based reply we keep the 'Re: ...' subject line
@@ -256,7 +256,7 @@ function initComposeModal() {
     $('#composer').modal('toggle');
   });
   const tokenfieldConfig = {
-    delimiter: [',', ';', ' '], // Must be in sync with SplitFunc (utils.go)
+    delimiters: [',', ';', ' '], // Must be in sync with SplitFunc (utils.go)
     inputType: 'email',
     createTokensOnBlur: true,
   };


### PR DESCRIPTION
I put this on top of the work by Emil Sit, which still had a couple of issues.  The To and Cc fields still wouldn't get filled in because of a misnamed field in the tokenFieldConfig.  And the split of the fields need to use spaces and commas, too.