### PR TITLE
Use VARA HF/FM defaults if undefined in config

### DIFF
--- a/config.go
+++ b/config.go
@@ -44,6 +44,14 @@ func LoadConfig(cfgPath string, fallback cfg.Config) (config cfg.Config, err err
 		config.Pactor = cfg.DefaultConfig.Pactor
 	}
 
+	// Ensure VARA FM and VARA HF has default values
+	if config.VaraHF == (cfg.VaraConfig{}) {
+		config.VaraHF = cfg.DefaultConfig.VaraHF
+	}
+	if config.VaraFM == (cfg.VaraConfig{}) {
+		config.VaraFM = cfg.DefaultConfig.VaraFM
+	}
+
 	// TODO: Remove after some release cycles (2019-09-29)
 	if config.GPSdAddrLegacy != "" {
 		config.GPSd.Addr = config.GPSdAddrLegacy


### PR DESCRIPTION
This ensures that existing configs without varahf/varafm config gets the default values.