### PR TITLE
Release v0.13.1

### DIFF
--- a/config.go
+++ b/config.go
@@ -44,6 +44,14 @@ func LoadConfig(cfgPath string, fallback cfg.Config) (config cfg.Config, err err
 		config.Pactor = cfg.DefaultConfig.Pactor
 	}
 
+	// Ensure VARA FM and VARA HF has default values
+	if config.VaraHF == (cfg.VaraConfig{}) {
+		config.VaraHF = cfg.DefaultConfig.VaraHF
+	}
+	if config.VaraFM == (cfg.VaraConfig{}) {
+		config.VaraFM = cfg.DefaultConfig.VaraFM
+	}
+
 	// TODO: Remove after some release cycles (2019-09-29)
 	if config.GPSdAddrLegacy != "" {
 		config.GPSd.Addr = config.GPSdAddrLegacy

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+pat (0.13.1) stable; urgency=medium
+
+  * Fix panic when using unregistered VARA instances
+  * Use VARA HF/FM defaults if undefined in config
+  * Fix case sensitive matching when resolving aux addresses' passwords
+
+ -- Martin Hebnes Pedersen <martin.h.pedersen@gmail.com>  Sat, 17 Sep 2022 09:05:48 +0200
+
 pat (0.13.0) stable; urgency=medium
 
   * Add support for VARAHF and VARAFM

--- a/exchange.go
+++ b/exchange.go
@@ -92,7 +92,7 @@ func sessionExchange(conn net.Conn, targetCall string, master bool) error {
 			return config.SecureLoginPassword, nil
 		}
 		for _, aux := range config.AuxAddrs {
-			if addr.Addr != aux.Address {
+			if !addr.EqualString(aux.Address) {
 				continue
 			}
 			switch {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/la5nta/wl2k-go v0.10.0
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.16
-	github.com/n8jja/Pat-Vara/vara v0.0.0-20220513234311-0b0963c08629
+	github.com/n8jja/Pat-Vara/vara v0.0.0-20220913192056-634bd0182343
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/pd0mz/go-maidenhead v1.0.0
 	github.com/peterh/liner v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/microcosm-cc/bluemonday v1.0.16 h1:kHmAq2t7WPWLjiGvzKa5o3HzSfahUKiOq7fAPUiMNIc=
 github.com/microcosm-cc/bluemonday v1.0.16/go.mod h1:Z0r70sCuXHig8YpBzCc5eGHAap2K7e/u082ZUpDRRqM=
-github.com/n8jja/Pat-Vara/vara v0.0.0-20220513234311-0b0963c08629 h1:p1TIQTMMkFr1F826SCHDyZ3CIo/axcyK9aCehZAhjPY=
-github.com/n8jja/Pat-Vara/vara v0.0.0-20220513234311-0b0963c08629/go.mod h1:Ets4MAjszge5NX2/Z/VLtqqWXJw1wnq7UQ1Xo2GfEj0=
+github.com/n8jja/Pat-Vara/vara v0.0.0-20220913192056-634bd0182343 h1:okNw+y8ZBuFVlqJYLy+fnVwcwnlcNDqrLfiPXBQCDHw=
+github.com/n8jja/Pat-Vara/vara v0.0.0-20220913192056-634bd0182343/go.mod h1:Ets4MAjszge5NX2/Z/VLtqqWXJw1wnq7UQ1Xo2GfEj0=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/paulrosania/go-charset v0.0.0-20151028000031-621bb39fcc83/go.mod h1:YnNlZP7l4MhyGQ4CBRwv6ohZTPrUJJZtEv4ZgADkbs4=

--- a/internal/buildinfo/VERSION.go
+++ b/internal/buildinfo/VERSION.go
@@ -15,7 +15,7 @@ const (
 	// Forks should NOT bump this unless they use a unique AppName. The Winlink
 	// system uses this to derive the "these users should upgrade" wall of shame
 	// from CMS connects.
-	Version = "0.13.0"
+	Version = "0.13.1"
 )
 
 // GitRev is the git commit hash that the binary was built at.

--- a/osx/pat.pkgproj
+++ b/osx/pat.pkgproj
@@ -588,7 +588,7 @@
 				<key>USE_HFS+_COMPRESSION</key>
 				<true/>
 				<key>VERSION</key>
-				<string>0.13.0</string>
+				<string>0.13.1</string>
 			</dict>
 			<key>UUID</key>
 			<string>5562F199-B4C6-48BC-98FA-5BBA494CB61F</string>


### PR DESCRIPTION
Small release, but I think it's best to get the VARA panic fix released as soon as possible.

Changelog:

* Fix panic when using unregistered VARA instances
* Use VARA HF/FM defaults if undefined in config
* Fix case sensitive matching when resolving aux addresses' passwords