### PR TITLE
Switch to more idiomatic config fields for VARA

### DIFF
--- a/config.go
+++ b/config.go
@@ -45,10 +45,10 @@ func LoadConfig(cfgPath string, fallback cfg.Config) (config cfg.Config, err err
 	}
 
 	// Ensure VARA FM and VARA HF has default values
-	if config.VaraHF == (cfg.VaraConfig{}) {
+	if config.VaraHF.IsZero() {
 		config.VaraHF = cfg.DefaultConfig.VaraHF
 	}
-	if config.VaraFM == (cfg.VaraConfig{}) {
+	if config.VaraFM.IsZero() {
 		config.VaraFM = cfg.DefaultConfig.VaraFM
 	}
 

--- a/connect.go
+++ b/connect.go
@@ -8,12 +8,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/la5nta/pat/cfg"
-	"github.com/la5nta/pat/internal/debug"
 	"log"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/la5nta/pat/cfg"
+	"github.com/la5nta/pat/internal/debug"
 
 	"github.com/harenber/ptc-go/v2/pactor"
 	"github.com/la5nta/wl2k-go/transport"
@@ -296,9 +297,9 @@ func initVaraModem(vModem *vara.Modem, scheme string, conf cfg.VaraConfig) error
 		_ = vModem.Close()
 	}
 	vConf := vara.ModemConfig{
-		Host:     conf.Host,
-		CmdPort:  conf.CmdPort,
-		DataPort: conf.DataPort,
+		Host:     conf.Host(),
+		CmdPort:  conf.CmdPort(),
+		DataPort: conf.DataPort(),
 	}
 	var err error
 	vModem, err = vara.NewModem(scheme, fOptions.MyCall, vConf)


### PR DESCRIPTION
As VARA is hardcoded to use port n+1 for the data stream, it seems unnecessary to support configuration of ctrl and data ports individually. By removing this option, we can use the same address config idioms as in the rest of the app. Also switched to from camelCase to under_score as this is what we use for all other fields.

Implemented backwards compatible by implementing the json.Unmarshaller interface.