### PR TITLE
Forms fix for to: and  cc: fields

### DIFF
--- a/internal/forms/forms.go
+++ b/internal/forms/forms.go
@@ -94,6 +94,8 @@ type FormFolder struct {
 type FormData struct {
 	TargetForm Form              `json:"target_form"`
 	Fields     map[string]string `json:"fields"`
+	MsgTo      string            `json:"msg_to"`
+	MsgCc      string            `json:"msg_cc"`
 	MsgSubject string            `json:"msg_subject"`
 	MsgBody    string            `json:"msg_body"`
 	MsgXML     string            `json:"msg_xml"`
@@ -103,6 +105,8 @@ type FormData struct {
 
 // MessageForm represents a concrete form-based message
 type MessageForm struct {
+	To             string
+	Cc             string
 	Subject        string
 	Body           string
 	AttachmentXML  string
@@ -195,6 +199,8 @@ func (m *Manager) PostFormDataHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		log.Printf("%s %s: %s", r.Method, r.URL.Path, err)
 	}
+	formData.MsgTo = formMsg.To
+	formData.MsgCc = formMsg.Cc
 	formData.MsgSubject = formMsg.Subject
 	formData.MsgBody = formMsg.Body
 	formData.MsgXML = formMsg.AttachmentXML
@@ -985,6 +991,8 @@ func (b formMessageBuilder) build() (MessageForm, error) {
 		replier,
 		formVarsAsXML)
 	retVal.AttachmentName = b.FormsMgr.GetXMLAttachmentNameForForm(b.Template, false)
+	retVal.To = strings.TrimSpace(retVal.To)
+	retVal.Cc = strings.TrimSpace(retVal.Cc)
 	retVal.Subject = strings.TrimSpace(retVal.Subject)
 	retVal.Body = strings.TrimSpace(retVal.Body)
 	return retVal, nil
@@ -1011,6 +1019,8 @@ func (b formMessageBuilder) initFormValues() {
 }
 
 func (b formMessageBuilder) scanTmplBuildMessage(tmplPath string) (MessageForm, error) {
+	inBody := false
+
 	infile, err := os.Open(tmplPath)
 	if err != nil {
 		return MessageForm{}, err
@@ -1026,11 +1036,15 @@ func (b formMessageBuilder) scanTmplBuildMessage(tmplPath string) (MessageForm, 
 		lineTmpl = fillPlaceholders(lineTmpl, placeholderRegEx, b.FormValues)
 		lineTmpl = strings.ReplaceAll(lineTmpl, "<MsgSender>", b.FormsMgr.config.MyCall)
 		lineTmpl = strings.ReplaceAll(lineTmpl, "<ProgramVersion>", "Pat "+b.FormsMgr.config.AppVersion)
-		if strings.HasPrefix(lineTmpl, "Form:") ||
-			strings.HasPrefix(lineTmpl, "ReplyTemplate:") ||
-			strings.HasPrefix(lineTmpl, "To:") ||
-			strings.HasPrefix(lineTmpl, "Msg:") {
+		if strings.HasPrefix(lineTmpl, "Form:") {
 			continue
+		}
+		if strings.HasPrefix(lineTmpl, "ReplyTemplate:") {
+			continue
+		}
+		if strings.HasPrefix(lineTmpl, "Msg:") {
+			lineTmpl = strings.TrimSpace(strings.TrimPrefix(lineTmpl, "Msg:"))
+			inBody = true
 		}
 		if b.Interactive {
 			matches := placeholderRegEx.FindAllStringSubmatch(lineTmpl, -1)
@@ -1053,8 +1067,14 @@ func (b formMessageBuilder) scanTmplBuildMessage(tmplPath string) (MessageForm, 
 		lineTmpl = fillPlaceholders(lineTmpl, placeholderRegEx, b.FormValues)
 		if strings.HasPrefix(lineTmpl, "Subject:") {
 			retVal.Subject = strings.TrimPrefix(lineTmpl, "Subject:")
-		} else {
+		} else if strings.HasPrefix(lineTmpl, "To:") {
+			retVal.To = strings.TrimPrefix(lineTmpl, "To:")
+		} else if strings.HasPrefix(lineTmpl, "Cc:") {
+			retVal.Cc = strings.TrimPrefix(lineTmpl, "Cc:")
+		} else if inBody {
 			retVal.Body += lineTmpl + "\n"
+		} else {
+			log.Printf("skipping unknown template line: '%s'", lineTmpl)
 		}
 	}
 

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -238,6 +238,12 @@ function pollFormData() {
 function writeFormDataToComposer(data) {
   if (data.target_form) {
     $('#msg_body').val(data.msg_body);
+    if (data.msg_to) {
+      $('#msg_to').tokenfield('setTokens', data.msg_to.split(";").filter(Boolean));
+    }
+    if (data.msg_cc) {
+      $('#msg_cc').tokenfield('setTokens', data.msg_cc.split(";").filter(Boolean));
+    }
     if (data.msg_subject) {
       // in case of composing a form-based reply we keep the 'Re: ...' subject line
       $('#msg_subject').val(data.msg_subject);

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -239,10 +239,10 @@ function writeFormDataToComposer(data) {
   if (data.target_form) {
     $('#msg_body').val(data.msg_body);
     if (data.msg_to) {
-      $('#msg_to').tokenfield('setTokens', data.msg_to.split(";").filter(Boolean));
+      $('#msg_to').tokenfield('setTokens', data.msg_to.split(/[ ;,]/).filter(Boolean));
     }
     if (data.msg_cc) {
-      $('#msg_cc').tokenfield('setTokens', data.msg_cc.split(";").filter(Boolean));
+      $('#msg_cc').tokenfield('setTokens', data.msg_cc.split(/[ ;,]/).filter(Boolean));
     }
     if (data.msg_subject) {
       // in case of composing a form-based reply we keep the 'Re: ...' subject line


### PR DESCRIPTION
This is the second try, I fixed the issues you pointed out.

I put this on top of the work by Emil Sit, which still had a couple of issues. The To and Cc fields still wouldn't get filled in because the split of the fields need to use spaces and commas, too.

This is on top of your "develop" branch, not master.