### PR TITLE
Fix `varaHFModem`/`varaFMModem` vars not being set on init

### DIFF
--- a/exchange.go
+++ b/exchange.go
@@ -190,7 +190,7 @@ func abortActiveConnection(dirty bool) (ok bool) {
 			}
 		}()
 		return true
-	case varaFMModem != nil:
+	case varaFMModem != nil && !varaFMModem.Idle():
 		log.Println("Disconnecting varafm...")
 		go func() {
 			if err := varaFMModem.Close(); err != nil {
@@ -198,7 +198,7 @@ func abortActiveConnection(dirty bool) (ok bool) {
 			}
 		}()
 		return true
-	case varaHFModem != nil:
+	case varaHFModem != nil && !varaHFModem.Idle():
 		log.Println("Disconnecting varahf...")
 		go func() {
 			if err := varaHFModem.Close(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/la5nta/wl2k-go v0.11.1
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.16
-	github.com/n8jja/Pat-Vara v1.0.2
+	github.com/n8jja/Pat-Vara v1.0.3
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/pd0mz/go-maidenhead v1.0.0
 	github.com/peterh/liner v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/microcosm-cc/bluemonday v1.0.16 h1:kHmAq2t7WPWLjiGvzKa5o3HzSfahUKiOq7fAPUiMNIc=
 github.com/microcosm-cc/bluemonday v1.0.16/go.mod h1:Z0r70sCuXHig8YpBzCc5eGHAap2K7e/u082ZUpDRRqM=
-github.com/n8jja/Pat-Vara v1.0.2 h1:fEv216S1/JdUgM1ofcb5mqC74ym30wuTbkdlz2Q451k=
-github.com/n8jja/Pat-Vara v1.0.2/go.mod h1:eVJvcJZDzHuDoHShGHgNRBhd1i8IOr/Qktc79Tb+dBY=
+github.com/n8jja/Pat-Vara v1.0.3 h1:TPd+Zly6FIsqTigzBtnK1usCuvawaFnX8zQpeVWI0dI=
+github.com/n8jja/Pat-Vara v1.0.3/go.mod h1:eVJvcJZDzHuDoHShGHgNRBhd1i8IOr/Qktc79Tb+dBY=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/paulrosania/go-charset v0.0.0-20151028000031-621bb39fcc83/go.mod h1:YnNlZP7l4MhyGQ4CBRwv6ohZTPrUJJZtEv4ZgADkbs4=


### PR DESCRIPTION
Ref #387 . As it turns out, the global variables `varaHFModem` and `varaFMModem` was never set. It looks like the intention was that `func initVaraModem` would set these since it sets the pointer value vModem passed as the first argument to the function. However, this is not how it works. In order to do this, the function would need to take a pointer to pointer (`vModem **vara.Modem`).. but that is just a mess to work with.

To cut this story short, I have fixed this issue. What we now need to do is to confirm that this does not break anything. Since the global vars was never set, the call to `vModem.Close()` was actually never called and the initialization took place only once.

In order to make sure this still works as intended, I need some help testing the following:
1. Start `pat http`
2. Make a successful VARA connection.
3. Wait a couple of seconds.
4. Make another VARA connection.
5. Gracefully shut down Pat (ctrl+c) and verify that no error is logged.

On step 4, Pat will actually close the current VARA modem connection and re-init the modem as originally intended. This have the potential of failing if `Close()` does not behave as expected. Step 5 also have the potential of throwing errors, as we now properly Close VARA HF/FM modem connection when Pat shuts down (`func cleanup()` main.go).