### PR TITLE
VARA: Fix panic by avoiding use of atomic package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,3 +24,5 @@ require (
 	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 )
+
+replace github.com/n8jja/Pat-Vara => github.com/martinhpedersen/Pat-Vara v0.0.0-20230502052346-487f03d3963f

--- a/go.sum
+++ b/go.sum
@@ -41,13 +41,13 @@ github.com/la5nta/wl2k-go v0.7.3/go.mod h1:rTQaxPiAFD3pWGWN8Lh+BskN3Fpii84GoVwpT
 github.com/la5nta/wl2k-go v0.9.2/go.mod h1:0c+/9KyDj7Ra7C/O4rVUYx1CzvdtS65di/93wlI22fo=
 github.com/la5nta/wl2k-go v0.11.1 h1:mD6xGD/z2D4lu/qlL6hfZX06F0JIJ+Eny/BPGOF4LUg=
 github.com/la5nta/wl2k-go v0.11.1/go.mod h1:0c+/9KyDj7Ra7C/O4rVUYx1CzvdtS65di/93wlI22fo=
+github.com/martinhpedersen/Pat-Vara v0.0.0-20230502052346-487f03d3963f h1:Bl35akgPOriTDZ4ARKW9d+Iywbpp+PwgS6b24V/zpiE=
+github.com/martinhpedersen/Pat-Vara v0.0.0-20230502052346-487f03d3963f/go.mod h1:eVJvcJZDzHuDoHShGHgNRBhd1i8IOr/Qktc79Tb+dBY=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/microcosm-cc/bluemonday v1.0.16 h1:kHmAq2t7WPWLjiGvzKa5o3HzSfahUKiOq7fAPUiMNIc=
 github.com/microcosm-cc/bluemonday v1.0.16/go.mod h1:Z0r70sCuXHig8YpBzCc5eGHAap2K7e/u082ZUpDRRqM=
-github.com/n8jja/Pat-Vara v1.0.2 h1:fEv216S1/JdUgM1ofcb5mqC74ym30wuTbkdlz2Q451k=
-github.com/n8jja/Pat-Vara v1.0.2/go.mod h1:eVJvcJZDzHuDoHShGHgNRBhd1i8IOr/Qktc79Tb+dBY=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/paulrosania/go-charset v0.0.0-20151028000031-621bb39fcc83/go.mod h1:YnNlZP7l4MhyGQ4CBRwv6ohZTPrUJJZtEv4ZgADkbs4=


### PR DESCRIPTION
I've forked Pat-Vara v1.0.3 (https://github.com/n8jja/Pat-Vara/pull/36). This PR switches to the fork so we can release a hotfix (v0.14.1) for #402.