### PR TITLE
Fix small typo in connection cancellation message

### DIFF
--- a/exchange.go
+++ b/exchange.go
@@ -162,7 +162,7 @@ func abortActiveConnection(dirty bool) (ok bool) {
 	switch {
 	case dialing != nil:
 		// If we're currently dialing a transport, attempt to abort by cancelling the associated context.
-		log.Printf("Got abort signal while dailing %s, cancelling...", dialing.Scheme)
+		log.Printf("Got abort signal while dialing %s, cancelling...", dialing.Scheme)
 		dialCancelFunc()
 		return true
 	case exchangeConn != nil:


### PR DESCRIPTION
Spotted this while canceling connections earlier today, figured I'd toss a quick PR your way.  Typos stand out blatantly to me haha :)  If fixes like this are not wanted, no problem, don't feel obligated to merge it.  Cheers and 73.