### PR TITLE
web: Add all the ax25 transports to the transport menu

### DIFF
--- a/web/src/index.html
+++ b/web/src/index.html
@@ -199,17 +199,16 @@
                           data-width="100%"
                           id="transportSelect"
                         >
-                          <optgroup label="transports">
-                            <option value="ardop">ARDOP</option>
-                            <option value="ax25">AX.25</option>
+                          <option value="ardop">ARDOP</option>
+                          <option value="ax25">AX.25</option>
+                          <option value="pactor">PACTOR</option>
+                          <option value="telnet">Telnet</option>
+                          <option value="varafm">VARA FM</option>
+                          <option value="varahf">VARA HF</option>
+                          <optgroup label="advanced">
                             <option value="ax25+agwpe">AX.25+agwpe</option>
                             <option value="ax25+linux">AX.25+linux</option>
                             <option value="ax25+serial-tnc">AX.25+serial-tnc</option>
-                            <option value="pactor">Pactor</option>
-                            <option value="serial-tnc">serial-tnc</option>
-                            <option value="telnet">telnet</option>
-                            <option value="varafm">VARA FM</option>
-                            <option value="varahf">VARA HF</option>
                           </optgroup>
                         </select>
                       </div>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -202,6 +202,9 @@
                           <optgroup label="transports">
                             <option value="ardop">ARDOP</option>
                             <option value="ax25">AX.25</option>
+                            <option value="ax25+agwpe">AX.25+agwpe</option>
+                            <option value="ax25+linux">AX.25+linux</option>
+                            <option value="ax25+serial-tnc">AX.25+serial-tnc</option>
                             <option value="pactor">Pactor</option>
                             <option value="serial-tnc">serial-tnc</option>
                             <option value="telnet">telnet</option>

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -460,6 +460,9 @@ function initConnectModal() {
         break;
       case 'serial-tnc':
       case 'ax25':
+      case 'ax25+linux':
+      case 'ax25+agwpe':
+      case 'ax25+serial-tnc':
         $('#modeSearchSelect').val('packet');
         break;
       default:
@@ -694,7 +697,7 @@ function refreshExtraInputGroups() {
       $('#freqInputDiv').show();
   }
 
-  if (transport == 'ax25' || transport == 'serial-tnc') {
+  if (transport.startsWith('ax25') || transport == 'serial-tnc') {
     $('#radioOnlyInput')[0].checked = false;
     $('#radioOnlyInputDiv').hide();
   } else {

--- a/web/src/js/app.js
+++ b/web/src/js/app.js
@@ -458,7 +458,6 @@ function initConnectModal() {
       case 'varahf':
         $('#modeSearchSelect').val($(e.target).val());
         break;
-      case 'serial-tnc':
       case 'ax25':
       case 'ax25+linux':
       case 'ax25+agwpe':
@@ -697,7 +696,7 @@ function refreshExtraInputGroups() {
       $('#freqInputDiv').show();
   }
 
-  if (transport.startsWith('ax25') || transport == 'serial-tnc') {
+  if (transport.startsWith('ax25')) {
     $('#radioOnlyInput')[0].checked = false;
     $('#radioOnlyInputDiv').hide();
   } else {


### PR DESCRIPTION
So they can be individually selected and used from the web page.