### PR TITLE
Forms date formatting

### DIFF
--- a/internal/forms/date.go
+++ b/internal/forms/date.go
@@ -6,9 +6,9 @@ import (
 )
 
 func formatDateTime(t time.Time) string    { return t.Format("2006-01-02 15:04:05") }
-func formatDateTimeUTC(t time.Time) string { return t.UTC().Format("2006-01-02 15:04:05Z") }
+func formatDateTimeUTC(t time.Time) string { return t.UTC().Format("2006-01-02 15:04:05Z07:00") }
 func formatDate(t time.Time) string        { return t.Format("2006-01-02") }
 func formatTime(t time.Time) string        { return t.Format("15:04:05") }
-func formatDateUTC(t time.Time) string     { return t.UTC().Format("2006-01-02Z") }
-func formatTimeUTC(t time.Time) string     { return t.UTC().Format("15:04:05Z") }
-func formatUDTG(t time.Time) string        { return strings.ToUpper(t.UTC().Format("021504Z Jan 2006")) }
+func formatDateUTC(t time.Time) string     { return t.UTC().Format("2006-01-02Z07:00") }
+func formatTimeUTC(t time.Time) string     { return t.UTC().Format("15:04:05Z07:00") }
+func formatUDTG(t time.Time) string        { return strings.ToUpper(t.UTC().Format("021504Z07:00 Jan 2006")) }

--- a/internal/forms/date.go
+++ b/internal/forms/date.go
@@ -1,0 +1,14 @@
+package forms
+
+import (
+	"strings"
+	"time"
+)
+
+func formatDateTime(t time.Time) string    { return t.Format("2006-01-02 15:04:05") }
+func formatDateTimeUTC(t time.Time) string { return t.UTC().Format("2006-01-02 15:04:05Z") }
+func formatDate(t time.Time) string        { return t.Format("2006-01-02") }
+func formatTime(t time.Time) string        { return t.Format("15:04:05") }
+func formatDateUTC(t time.Time) string     { return t.UTC().Format("2006-01-02Z") }
+func formatTimeUTC(t time.Time) string     { return t.UTC().Format("15:04:05Z") }
+func formatUDTG(t time.Time) string        { return strings.ToUpper(t.UTC().Format("021504Z Jan 2006")) }

--- a/internal/forms/date_test.go
+++ b/internal/forms/date_test.go
@@ -1,0 +1,29 @@
+package forms
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDateFormat(t *testing.T) {
+	now := time.Date(2023, 12, 31, 23, 59, 59, 0, time.FixedZone("UTC-4", -4*60*60))
+
+	tests := []struct {
+		fn     func(t time.Time) string
+		expect string
+	}{
+		{formatDateTime, "2023-12-31 23:59:59"},
+		{formatDateTimeUTC, "2024-01-01 03:59:59Z"},
+		{formatDate, "2023-12-31"},
+		{formatTime, "23:59:59"},
+		{formatDateUTC, "2024-01-01Z"},
+		{formatTimeUTC, "03:59:59Z"},
+		{formatUDTG, "010359Z JAN 2024"},
+	}
+
+	for i, tt := range tests {
+		if got := tt.fn(now); got != tt.expect {
+			t.Errorf("%d: got %q expected %q", i, got, tt.expect)
+		}
+	}
+}

--- a/internal/forms/forms.go
+++ b/internal/forms/forms.go
@@ -814,16 +814,7 @@ func (m *Manager) fillFormTemplate(absPathTemplate string, formDestURL string, p
 		log.Printf("Warning: unsupported string encoding in template %s, expected utf-8", absPathTemplate)
 	}
 
-	var (
-		now            = time.Now()
-		nowDateTime    = now.Format("2006-01-02 15:04:05")
-		nowDateTimeUTC = now.UTC().Format("2006-01-02 15:04:05Z")
-		nowDate        = now.Format("2006-01-02")
-		nowTime        = now.Format("15:04:05")
-		nowDateUTC     = now.UTC().Format("2006-01-02Z")
-		nowTimeUTC     = now.UTC().Format("15:04:05Z")
-		udtg           = strings.ToUpper(now.UTC().Format("021504Z Jan 2006"))
-	)
+	now := time.Now()
 	validPos := "NO"
 	nowPos, err := m.gpsPos()
 	if err != nil {
@@ -843,13 +834,13 @@ func (m *Manager) fillFormTemplate(absPathTemplate string, formDestURL string, p
 		l = strings.ReplaceAll(l, "{MsgSender}", m.config.MyCall)
 		l = strings.ReplaceAll(l, "{Callsign}", m.config.MyCall)
 		l = strings.ReplaceAll(l, "{ProgramVersion}", "Pat "+m.config.AppVersion)
-		l = strings.ReplaceAll(l, "{DateTime}", nowDateTime)
-		l = strings.ReplaceAll(l, "{UDateTime}", nowDateTimeUTC)
-		l = strings.ReplaceAll(l, "{Date}", nowDate)
-		l = strings.ReplaceAll(l, "{UDate}", nowDateUTC)
-		l = strings.ReplaceAll(l, "{UDTG}", udtg)
-		l = strings.ReplaceAll(l, "{Time}", nowTime)
-		l = strings.ReplaceAll(l, "{UTime}", nowTimeUTC)
+		l = strings.ReplaceAll(l, "{DateTime}", formatDateTime(now))
+		l = strings.ReplaceAll(l, "{UDateTime}", formatDateTimeUTC(now))
+		l = strings.ReplaceAll(l, "{Date}", formatDate(now))
+		l = strings.ReplaceAll(l, "{UDate}", formatDateUTC(now))
+		l = strings.ReplaceAll(l, "{UDTG}", formatUDTG(now))
+		l = strings.ReplaceAll(l, "{Time}", formatTime(now))
+		l = strings.ReplaceAll(l, "{UTime}", formatTimeUTC(now))
 		l = strings.ReplaceAll(l, "{GPS}", gpsFmt(degreeMinute, nowPos))
 		l = strings.ReplaceAll(l, "{GPS_DECIMAL}", gpsFmt(decimal, nowPos))
 		l = strings.ReplaceAll(l, "{GPS_SIGNED_DECIMAL}", gpsFmt(signedDecimal, nowPos))


### PR DESCRIPTION
I discovered an error in the time formatting strings we use in the forms package, so I wanted to write some tests and fix this.

As it turns out, the error did not affect the outputted strings. It only manifests when outputting datetime strings not in UTC, which none of these does. Anyway, I've added some tests and fixed the layout strings 🙂 