### PR TITLE
Add connection prehook for scripted node traversal

### DIFF
--- a/conn_prehook.go
+++ b/conn_prehook.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type prehookConn struct {
+	net.Conn
+	br *bufio.Reader
+
+	executable string
+	args       []string
+}
+
+func NewPrehookConn(conn net.Conn, executable string, args ...string) prehookConn {
+	return prehookConn{
+		Conn:       conn,
+		br:         bufio.NewReader(conn),
+		executable: executable,
+		args:       args,
+	}
+}
+
+func (p prehookConn) Read(b []byte) (int, error) { return p.br.Read(b) }
+
+// Wait waits for the prehook process to exit, returning nil if the process
+// terminated successfully (exit code 0).
+func (p prehookConn) Wait(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, p.executable, p.args...)
+	cmd.WaitDelay = time.Second
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = p.Conn
+	cmdStdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	// Copy environment to the child process. Also include additional
+	// relevant variables: REMOTE_ADDR, LOCAL_ADDR and the output of the
+	// env command.
+	cmd.Env = append(append(os.Environ(),
+		"PAT_REMOTE_ADDR="+p.RemoteAddr().String(),
+		"PAT_LOCAL_ADDR="+p.LocalAddr().String(),
+	), envAll()...)
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	g.Go(func() error { return p.forwardLines(ctx, cmdStdin) })
+	g.Go(func() error { defer cancel(); return cmd.Wait() })
+	return g.Wait()
+}
+
+// forwardLines forwards data from to the spawned process line by line.
+//
+// The line delimiter is CR or LF, but to facilitate scripting we append LF if
+// it's missing.
+//
+// Wait one second after each line, to give the process time to terminate
+// before delivering the next line.
+func (p prehookConn) forwardLines(ctx context.Context, w io.Writer) error {
+	// Copy the lines to stdout so the user can see what's going on.
+	stdinBuffered := bufio.NewWriter(io.MultiWriter(w, os.Stdout))
+	defer stdinBuffered.Flush()
+
+	var isPrefix bool // true if we're in the middle of a line
+	for {
+		if !isPrefix {
+			// A line was just terminated (or no data has been read yet).
+			// Flush and wait one second to check if the process
+			// exited. If not we assume it expects an upcoming line.
+			if err := stdinBuffered.Flush(); err != nil {
+				return fmt.Errorf("child process exited prematurely: %w", err)
+			}
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(time.Second):
+			}
+		}
+
+		b, err := p.br.ReadByte()
+		if err != nil {
+			return err
+		}
+		stdinBuffered.WriteByte(b)
+		isPrefix = !(b == '\n' || b == '\r')
+
+		// Make sure CR is always followed by LF. It's easier to deal with in scripts.
+		if b == '\r' {
+			stdinBuffered.WriteByte('\n')
+			// Peek to check if the next byte is the LF we just wrote, in which case discard it.
+			if peek, _ := p.br.Peek(1); len(peek) > 0 && peek[0] == '\n' {
+				p.br.Discard(1)
+			}
+		}
+	}
+}

--- a/conn_prehook.go
+++ b/conn_prehook.go
@@ -36,7 +36,6 @@ func (p prehookConn) Read(b []byte) (int, error) { return p.br.Read(b) }
 // terminated successfully (exit code 0).
 func (p prehookConn) Wait(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, p.executable, p.args...)
-	cmd.WaitDelay = time.Second
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = p.Conn
 	cmdStdin, err := cmd.StdinPipe()

--- a/connect.go
+++ b/connect.go
@@ -184,6 +184,13 @@ func Connect(connectStr string) (success bool) {
 	dialing = url
 	websocketHub.UpdateStatus()
 
+	if exec := url.Params.Get("prehook"); exec != "" {
+		if err := VerifyPrehook(exec); err != nil {
+			log.Printf("prehook invalid: %s", err)
+			return
+		}
+	}
+
 	log.Printf("Connecting to %s (%s)...", url.Target, url.Scheme)
 	conn, err := transport.DialURLContext(ctx, url)
 

--- a/connect.go
+++ b/connect.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/la5nta/pat/cfg"
 	"github.com/la5nta/pat/internal/debug"
+	"github.com/la5nta/pat/internal/prehook"
 
 	"github.com/harenber/ptc-go/v2/pactor"
 	"github.com/la5nta/wl2k-go/transport"
@@ -185,7 +186,7 @@ func Connect(connectStr string) (success bool) {
 	websocketHub.UpdateStatus()
 
 	if exec := url.Params.Get("prehook"); exec != "" {
-		if err := VerifyPrehook(exec); err != nil {
+		if err := prehook.Verify(exec); err != nil {
 			log.Printf("prehook invalid: %s", err)
 			return
 		}
@@ -211,7 +212,7 @@ func Connect(connectStr string) (success bool) {
 
 	if exec := url.Params.Get("prehook"); exec != "" {
 		log.Println("Running prehook...")
-		prehookConn := NewPrehookConn(conn, exec, url.Params["prehook-param"]...)
+		prehookConn := prehook.Wrap(conn, envAll(), exec, url.Params["prehook-param"]...)
 		if err := prehookConn.Wait(ctx); err != nil {
 			conn.Close()
 			log.Printf("Prehook script failed: %s", err)

--- a/connect.go
+++ b/connect.go
@@ -202,6 +202,18 @@ func Connect(connectStr string) (success bool) {
 		return
 	}
 
+	if exec := url.Params.Get("prehook"); exec != "" {
+		log.Println("Running prehook...")
+		prehookConn := NewPrehookConn(conn, exec, url.Params["prehook-param"]...)
+		if err := prehookConn.Wait(ctx); err != nil {
+			conn.Close()
+			log.Printf("Prehook script failed: %s", err)
+			return
+		}
+		log.Println("Prehook succeeded")
+		conn = prehookConn
+	}
+
 	err = exchange(conn, url.Target, false)
 	if err != nil {
 		log.Printf("Exchange failed: %s", err)

--- a/env.go
+++ b/env.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/la5nta/pat/internal/buildinfo"
 )
@@ -15,28 +16,30 @@ func envHandle(_ context.Context, _ []string) {
 }
 
 func writeEnvAll(w io.Writer) {
-	writeEnv(w, "PAT_MYCALL", fOptions.MyCall)
-	writeEnv(w, "PAT_LOCATOR", config.Locator)
-	writeEnv(w, "PAT_VERSION", buildinfo.Version)
-	writeEnv(w, "PAT_ARCH", runtime.GOARCH)
-	writeEnv(w, "PAT_OS", runtime.GOOS)
-	writeEnv(w, "PAT_MAILBOX_PATH", fOptions.MailboxPath)
-	writeEnv(w, "PAT_CONFIG_PATH", fOptions.ConfigPath)
-	writeEnv(w, "PAT_LOG_PATH", fOptions.LogPath)
-	writeEnv(w, "PAT_EVENTLOG_PATH", fOptions.EventLogPath)
-	writeEnv(w, "PAT_FORMS_PATH", fOptions.FormsPath)
-	writeEnv(w, "PAT_DEBUG", os.Getenv("PAT_DEBUG"))
-	writeEnv(w, "PAT_WEB_DEV_ADDR", os.Getenv("PAT_WEB_DEV_ADDR"))
-
-	writeEnv(w, "ARDOP_DEBUG", os.Getenv("ARDOP_DEBUG"))
-	writeEnv(w, "PACTOR_DEBUG", os.Getenv("PACTOR_DEBUG"))
-	writeEnv(w, "AGWPE_DEBUG", os.Getenv("AGWPE_DEBUG"))
-	writeEnv(w, "VARA_DEBUG", os.Getenv("VARA_DEBUG"))
-
-	writeEnv(w, "GZIP_EXPERIMENT", os.Getenv("GZIP_EXPERIMENT"))
-	writeEnv(w, "ARDOP_FSKONLY_EXPERIMENT", os.Getenv("ARDOP_FSKONLY_EXPERIMENT"))
+	fmt.Fprintln(w, strings.Join(envAll(), "\n"))
 }
 
-func writeEnv(w io.Writer, k, v string) {
-	fmt.Fprintf(w, "%s=\"%s\"\n", k, v)
+func envAll() []string {
+	return []string{
+		`PAT_MYCALL="` + fOptions.MyCall + `"`,
+		`PAT_LOCATOR="` + config.Locator + `"`,
+		`PAT_VERSION="` + buildinfo.Version + `"`,
+		`PAT_ARCH="` + runtime.GOARCH + `"`,
+		`PAT_OS="` + runtime.GOOS + `"`,
+		`PAT_MAILBOX_PATH="` + fOptions.MailboxPath + `"`,
+		`PAT_CONFIG_PATH="` + fOptions.ConfigPath + `"`,
+		`PAT_LOG_PATH="` + fOptions.LogPath + `"`,
+		`PAT_EVENTLOG_PATH="` + fOptions.EventLogPath + `"`,
+		`PAT_FORMS_PATH="` + fOptions.FormsPath + `"`,
+		`PAT_DEBUG="` + os.Getenv("PAT_DEBUG") + `"`,
+		`PAT_WEB_DEV_ADDR="` + os.Getenv("PAT_WEB_DEV_ADDR") + `"`,
+
+		`ARDOP_DEBUG="` + os.Getenv("ARDOP_DEBUG") + `"`,
+		`PACTOR_DEBUG="` + os.Getenv("PACTOR_DEBUG") + `"`,
+		`AGWPE_DEBUG="` + os.Getenv("AGWPE_DEBUG") + `"`,
+		`VARA_DEBUG="` + os.Getenv("VARA_DEBUG") + `"`,
+
+		`GZIP_EXPERIMENT="` + os.Getenv("GZIP_EXPERIMENT") + `"`,
+		`ARDOP_FSKONLY_EXPERIMENT="` + os.Getenv("ARDOP_FSKONLY_EXPERIMENT") + `"`,
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/pd0mz/go-maidenhead v1.0.0
 	github.com/peterh/liner v1.2.1
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/sync v0.5.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ golang.org/x/crypto v0.0.0-20210813211128-0a44fdfbc16e/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d h1:LO7XpTYMwTqxjLcGWPijK3vRXg1aWdlNOVOHRq45d7c=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
+golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210223212115-eede4237b368/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/usage.go
+++ b/usage.go
@@ -36,7 +36,7 @@ params:
   ?prehook=     Sets an executable middleware to run before the connection is handed over to the B2F protocol.
                  The executable must be given as full path, or a file located in $PATH or {CONFIG_DIR}/prehooks/.
 		 Received packets are forwarded to STDIN. Data written to STDOUT forwarded to the remote node.
-		 Additional arguments can be passed with one or more ?prehook-arg=.
+		 Additional arguments can be passed with one or more &prehook-arg=.
 		 Environment variables describing the dialed connection are provided.
                  Useful for packet node traversal. Supported across all transports.
 `

--- a/usage.go
+++ b/usage.go
@@ -33,6 +33,12 @@ path:
 params:
   ?freq=        Sets QSY frequency (ardop and ax25 only)
   ?host=        Overrides the host part of the path. Useful for serial-tnc to specify e.g. /dev/ttyS0.
+  ?prehook=     Sets an executable middleware to run before the connection is handed over to the B2F protocol.
+                 The executable must be given as full path, or a file located in $PATH or {CONFIG_DIR}/prehooks/.
+		 Received packets are forwarded to STDIN. Data written to STDOUT forwarded to the remote node.
+		 Additional arguments can be passed with one or more ?prehook-arg=.
+		 Environment variables describing the dialed connection are provided.
+                 Useful for packet node traversal. Supported across all transports.
 `
 	ExampleConnect = `
   connect telnet                       (alias) Connect to one of the Winlink Common Message Servers via tcp.


### PR DESCRIPTION
Adds low-level connection prehook for all transports, implemented by spawning a user-defined process communicating with the remote station over stdio.

This enables scripted node traversal (#114) at the lowest possible level. To make it more practical and user-friendly, we need to add a layer on top. Not everyone is comfortable writing bash scripts/programs able to do this, so we need a simplified language with just enough flexibility to express the command/response sequences commonly used in packet node traversal.

------

TODO
- [ ] Write documentation
    - [x] New connect URI query parameters (wiki + `pat connect help`)
    - [ ] Describe the protocol between Pat and the spawned process (wiki)