### PR TITLE
Add support for Message Templates (templates without HTML Forms)

### DIFF
--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -17,6 +17,8 @@ func init() {
 	enabled, _ = strconv.ParseBool(os.Getenv(EnvVar))
 }
 
+func Enabled() bool { return enabled }
+
 func Printf(format string, v ...interface{}) {
 	if !enabled {
 		return

--- a/internal/forms/prompt.go
+++ b/internal/forms/prompt.go
@@ -1,0 +1,72 @@
+package forms
+
+import (
+	"regexp"
+	"strings"
+)
+
+type Select struct {
+	Prompt  string
+	Options []Option
+}
+
+type Ask struct {
+	Prompt    string
+	Multiline bool
+}
+
+type Option struct {
+	Item  string
+	Value string
+}
+
+func promptAsks(str string, promptFn func(Ask) string) string {
+	re := regexp.MustCompile(`(?i)<Ask\s+([^,]+)(,[^>]+)?>`)
+	for {
+		tokens := re.FindAllStringSubmatch(str, -1)
+		if len(tokens) == 0 {
+			return str
+		}
+		replace, prompt, options := tokens[0][0], tokens[0][1], strings.TrimPrefix(tokens[0][2], ",")
+		a := Ask{Prompt: prompt, Multiline: strings.EqualFold(options, "MU")}
+		ans := promptFn(a)
+		str = strings.Replace(str, replace, ans, 1)
+	}
+}
+
+func promptSelects(str string, promptFn func(Select) Option) string {
+	re := regexp.MustCompile(`(?i)<Select\s+([^,]+)(,[^>]+)?>`)
+	for {
+		tokens := re.FindAllStringSubmatch(str, -1)
+		if len(tokens) == 0 {
+			return str
+		}
+		replace, prompt, options := tokens[0][0], tokens[0][1], strings.Split(strings.TrimPrefix(tokens[0][2], ","), ",")
+		s := Select{Prompt: prompt}
+		for _, opt := range options {
+			item, value, ok := strings.Cut(opt, "=")
+			if !ok {
+				value = item
+			}
+			s.Options = append(s.Options, Option{Item: item, Value: value})
+		}
+		ans := promptFn(s)
+		str = strings.Replace(str, replace, ans.Value, 1)
+	}
+}
+
+func promptVars(str string, promptFn func(string) string) string {
+	re := regexp.MustCompile(`(?i)<Var\s+(\w+)\s*>`)
+	for {
+		tokens := re.FindAllStringSubmatch(str, -1)
+		if len(tokens) == 0 {
+			return str
+		}
+		replace, key := tokens[0][0], tokens[0][1]
+		ans := promptFn(key)
+		if ans == "" {
+			ans = "blank"
+		}
+		str = strings.Replace(str, replace, ans, 1)
+	}
+}

--- a/internal/forms/prompt_test.go
+++ b/internal/forms/prompt_test.go
@@ -1,0 +1,37 @@
+package forms
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestReplaceSelect(t *testing.T) {
+	tests := []struct {
+		In, Expect string
+		Answer     func(Select) Option
+	}{
+		{
+			In:     "",
+			Expect: "",
+			Answer: nil,
+		},
+		{
+			In:     "foobar",
+			Expect: "foobar",
+			Answer: nil,
+		},
+		{
+			In:     `Subj: //WL2K <Select Prioritet:,Routine=R/,Priority=P/,Immediate=O/,Flash=Z/> <Callsign>/<SeqNum> - <Var Subject>`,
+			Expect: `Subj: //WL2K R/ <Callsign>/<SeqNum> - <Var Subject>`,
+			Answer: func(s Select) Option { return s.Options[0] },
+		},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			got := promptSelects(tt.In, tt.Answer)
+			if got != tt.Expect {
+				t.Errorf("Expected %q, got %q", tt.Expect, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds supports for templating features typically used in text-only templates:
* `<Ask ...>` and `<Select ...>` tags
* `Def: variable=value` (typically used in combination with the above to initalize a template variable)

I did some refactoring in order to use the same set of _insertion tags_ for text templates as for the HTML forms.

Resolves #375.


I used this as a reference: http://www.philsherrod.com/Winlink/RMS_Express_Message_Templates.pdf.