### PR TITLE
Fix creation of configdir in prehook

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Copyright (c) 2020 Martin Hebnes Pedersen LA5NTA
 * KD8DRX - Will Davidson
 * KE8HMG - Andrew Huebner
 * KI7RMJ - Rainer Grosskopf
+* KM6LBU - Robert Hernandez
 * LA3QMA - Kai Günter Brandt
 * LA4TTA - Erlend Grimseid
 * LA5NTA - Martin Hebnes Pedersen

--- a/internal/prehook/prehook.go
+++ b/internal/prehook/prehook.go
@@ -12,21 +12,13 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"time"
 
 	"github.com/la5nta/pat/internal/debug"
-	"github.com/la5nta/pat/internal/directories"
 	"golang.org/x/sync/errgroup"
 )
 
 var ErrConnNotWrapped = errors.New("connection not wrapped for prehook")
-
-func init() {
-	// Add {config-dir}/prehooks/ to PATH
-	prehooksPath := filepath.Join(directories.ConfigDir(), "prehooks")
-	os.Setenv("PATH", fmt.Sprintf(`%s%c%s`, prehooksPath, os.PathListSeparator, os.Getenv("PATH")))
-}
 
 type Script struct {
 	File string

--- a/main.go
+++ b/main.go
@@ -208,6 +208,7 @@ var fOptions struct {
 	Listen       string
 	MailboxPath  string
 	ConfigPath   string
+	PrehooksPath string
 	LogPath      string
 	EventLogPath string
 	FormsPath    string
@@ -225,11 +226,13 @@ func optionsSet() *pflag.FlagSet {
 	defaultMBox := filepath.Join(directories.DataDir(), "mailbox")
 	defaultFormsPath := filepath.Join(directories.DataDir(), "Standard_Forms")
 	defaultConfigPath := filepath.Join(directories.ConfigDir(), "config.json")
+	defaultPrehooksPath := filepath.Join(directories.ConfigDir(), "prehooks")
 	defaultLogPath := filepath.Join(directories.StateDir(), strings.ToLower(buildinfo.AppName+".log"))
 	defaultEventLogPath := filepath.Join(directories.StateDir(), "eventlog.json")
 	set.StringVar(&fOptions.MailboxPath, "mbox", defaultMBox, "Path to mailbox directory.")
 	set.StringVar(&fOptions.FormsPath, "forms", defaultFormsPath, "Path to forms directory.")
 	set.StringVar(&fOptions.ConfigPath, "config", defaultConfigPath, "Path to config file.")
+	set.StringVar(&fOptions.PrehooksPath, "prehooks", defaultPrehooksPath, "Path to prehooks")
 	set.StringVar(&fOptions.LogPath, "log", defaultLogPath, "Path to log file. The file is truncated on each startup.")
 	set.StringVar(&fOptions.EventLogPath, "event-log", defaultEventLogPath, "Path to event log file.")
 
@@ -307,6 +310,8 @@ func main() {
 	if _, ok := os.LookupEnv("GZIP_EXPERIMENT"); !ok {
 		os.Setenv("GZIP_EXPERIMENT", "1")
 	}
+
+	os.Setenv("PATH", fmt.Sprintf(`%s%c%s`, fOptions.PrehooksPath, os.PathListSeparator, os.Getenv("PATH")))
 
 	// Parse configuration file
 	var err error


### PR DESCRIPTION
## Description

Related to: https://github.com/la5nta/pat/pull/432

While running `go test -v ./... ` I noticed that the config dir `~/.config/pat` was being created in my development
environment. I would not expect running tests to result create extra dirs within $XDG_CONFIG_HOME. This was use to the
`init()` function within prehooks.

I opted to moved the prehooks dir setup into `main.go` which aligns with the rest of the config setup so running the test
suite no longer results in an additional dir being created in $XDG_CONFIG_HOME.

## Tests

I dont have a good way to ensure that the prehook functionality still works a intended.  I can confirm that the
script gets found and executed on my shack PC:

Create the prehook:

```
mkdir ~/.config/path/prehooks
cat << EOF > ~/.config/pat/prehooks/my-prehook.sh
#!/bin/sh
echo "hello from prehook\r"
EOF
chmod +x ~/.config/pat/prehooks/my-prehook.sh
```

Attempt to connect to a gateway and call prehook:

```
# pat connect 'ax25:///WA6BGS-10?prehook=my-prehook.sh'
2024/04/15 18:51:35 Connecting to WA6BGS-10 (ax25+linux)...
2024/04/15 18:51:36 Running prehook...
2024/04/15 18:51:36 Prehook succeeded
2024/04/15 18:51:36 Connected to WA6BGS-10 (AX.25)
WA6BGS-10 - Linux RMS Gateway 2.5.1 Feb 16 2024 (DM12mr)

WA6BGS-10 Linux RMS Gateway 2.5.1, El Cajon, CA

INFO: Host Name cms.winlink.org, Port 8772
Connected
[WL2K-5.0-B2FWIHJM$]
;PQ: 25298039
CMS via WA6BGS-10 >
>FF
Login [963]:
2024/04/15 18:51:44 Exchange failed: Unexpected response: 'Login [963]:'
```
Im assuming that the `Unexpected response` was becuase I just echoed a random string. It also seems that
any output is getting gobbled up by the existing connection since I dont see the "hello from prehook" text.


Go tests are all still passing:

```
$ go test -v ./...
?       github.com/la5nta/pat/cfg       [no test files]
?       github.com/la5nta/pat/internal/buildinfo        [no test files]
?       github.com/la5nta/pat/internal/debug    [no test files]
?       github.com/la5nta/pat/internal/cmsapi   [no test files]
?       github.com/la5nta/pat/internal/directories      [no test files]
?       github.com/la5nta/pat/internal/gpsd     [no test files]
?       github.com/la5nta/pat/internal/osutil   [no test files]
?       github.com/la5nta/pat/internal/prehook  [no test files]
=== RUN   TestReadRigsFromEnv
=== RUN   TestReadRigsFromEnv/simple
=== RUN   TestReadRigsFromEnv/with_VFO
=== RUN   TestReadRigsFromEnv/full
--- PASS: TestReadRigsFromEnv (0.00s)
    --- PASS: TestReadRigsFromEnv/simple (0.00s)
    --- PASS: TestReadRigsFromEnv/with_VFO (0.00s)
    --- PASS: TestReadRigsFromEnv/full (0.00s)
=== RUN   Test_toURL
=== RUN   Test_toURL/ax25_1200
=== RUN   Test_toURL/ax25_9600
=== RUN   Test_toURL/adrop_2000
=== RUN   Test_toURL/adrop_500
=== RUN   Test_toURL/adrop_1000
=== RUN   Test_toURL/adrop_unspec
=== RUN   Test_toURL/pactor
=== RUN   Test_toURL/robust_packet
=== RUN   Test_toURL/vara_hf_500
=== RUN   Test_toURL/vara_hf_unspec
=== RUN   Test_toURL/vara_hf_2750
=== RUN   Test_toURL/vara_fm_narrow
=== RUN   Test_toURL/vara_fm_wide
--- PASS: Test_toURL (0.00s)
    --- PASS: Test_toURL/ax25_1200 (0.00s)
    --- PASS: Test_toURL/ax25_9600 (0.00s)
    --- PASS: Test_toURL/adrop_2000 (0.00s)
    --- PASS: Test_toURL/adrop_500 (0.00s)
    --- PASS: Test_toURL/adrop_1000 (0.00s)
    --- PASS: Test_toURL/adrop_unspec (0.00s)
    --- PASS: Test_toURL/pactor (0.00s)
    --- PASS: Test_toURL/robust_packet (0.00s)
    --- PASS: Test_toURL/vara_hf_500 (0.00s)
    --- PASS: Test_toURL/vara_hf_unspec (0.00s)
    --- PASS: Test_toURL/vara_hf_2750 (0.00s)
    --- PASS: Test_toURL/vara_fm_narrow (0.00s)
    --- PASS: Test_toURL/vara_fm_wide (0.00s)
PASS
ok      github.com/la5nta/pat   0.004s
=== RUN   TestInsertionTagReplacer
=== RUN   TestInsertionTagReplacer/<Callsign>
=== RUN   TestInsertionTagReplacer/<Date>
=== RUN   TestInsertionTagReplacer/<UDate>
=== RUN   TestInsertionTagReplacer/<Time>
=== RUN   TestInsertionTagReplacer/<UTime>
=== RUN   TestInsertionTagReplacer/<GPS_DECIMAL>
=== RUN   TestInsertionTagReplacer/<GPSLatitude>
=== RUN   TestInsertionTagReplacer/<GPSLongitude>
=== RUN   TestInsertionTagReplacer/<Latitude>
=== RUN   TestInsertionTagReplacer/<ProgramVersion>
=== RUN   TestInsertionTagReplacer/<MsgSender>
=== RUN   TestInsertionTagReplacer/<DateTime>
=== RUN   TestInsertionTagReplacer/<UDateTime>
=== RUN   TestInsertionTagReplacer/<GPS>
=== RUN   TestInsertionTagReplacer/<GPS_SIGNED_DECIMAL>
=== RUN   TestInsertionTagReplacer/<UDTG>
=== RUN   TestInsertionTagReplacer/<Day>
=== RUN   TestInsertionTagReplacer/<UDay>
=== RUN   TestInsertionTagReplacer/<GridSquare>
=== RUN   TestInsertionTagReplacer/<Longitude>
=== RUN   TestInsertionTagReplacer/<GPSValid>
--- PASS: TestInsertionTagReplacer (0.00s)
    --- PASS: TestInsertionTagReplacer/<Callsign> (0.00s)
    --- PASS: TestInsertionTagReplacer/<Date> (0.00s)
    --- PASS: TestInsertionTagReplacer/<UDate> (0.00s)
    --- PASS: TestInsertionTagReplacer/<Time> (0.00s)
    --- PASS: TestInsertionTagReplacer/<UTime> (0.00s)
    --- PASS: TestInsertionTagReplacer/<GPS_DECIMAL> (0.00s)
    --- PASS: TestInsertionTagReplacer/<GPSLatitude> (0.00s)
    --- PASS: TestInsertionTagReplacer/<GPSLongitude> (0.00s)
    --- PASS: TestInsertionTagReplacer/<Latitude> (0.00s)
    --- PASS: TestInsertionTagReplacer/<ProgramVersion> (0.00s)
    --- PASS: TestInsertionTagReplacer/<MsgSender> (0.00s)
    --- PASS: TestInsertionTagReplacer/<DateTime> (0.00s)
    --- PASS: TestInsertionTagReplacer/<UDateTime> (0.00s)
    --- PASS: TestInsertionTagReplacer/<GPS> (0.00s)
    --- PASS: TestInsertionTagReplacer/<GPS_SIGNED_DECIMAL> (0.00s)
    --- PASS: TestInsertionTagReplacer/<UDTG> (0.00s)
    --- PASS: TestInsertionTagReplacer/<Day> (0.00s)
    --- PASS: TestInsertionTagReplacer/<UDay> (0.00s)
    --- PASS: TestInsertionTagReplacer/<GridSquare> (0.00s)
    --- PASS: TestInsertionTagReplacer/<Longitude> (0.00s)
    --- PASS: TestInsertionTagReplacer/<GPSValid> (0.00s)
=== RUN   TestBuildXML
--- PASS: TestBuildXML (0.00s)
=== RUN   TestDateFormat
--- PASS: TestDateFormat (0.00s)
=== RUN   TestPlaceholderReplacer
=== RUN   TestPlaceholderReplacer/0
=== RUN   TestPlaceholderReplacer/1
=== RUN   TestPlaceholderReplacer/2
=== RUN   TestPlaceholderReplacer/3
--- PASS: TestPlaceholderReplacer (0.00s)
    --- PASS: TestPlaceholderReplacer/0 (0.00s)
    --- PASS: TestPlaceholderReplacer/1 (0.00s)
    --- PASS: TestPlaceholderReplacer/2 (0.00s)
    --- PASS: TestPlaceholderReplacer/3 (0.00s)
=== RUN   TestReplaceSelect
=== RUN   TestReplaceSelect/0
=== RUN   TestReplaceSelect/1
=== RUN   TestReplaceSelect/2
--- PASS: TestReplaceSelect (0.00s)
    --- PASS: TestReplaceSelect/0 (0.00s)
    --- PASS: TestReplaceSelect/1 (0.00s)
    --- PASS: TestReplaceSelect/2 (0.00s)
PASS
ok      github.com/la5nta/pat/internal/forms    0.006s
```
