### PR TITLE
Include and retain X-P2P header for P2P Only messages

### DIFF
--- a/cli_composer.go
+++ b/cli_composer.go
@@ -77,6 +77,7 @@ func composeMessageHeader(inReplyToMsg *fbb.Message, replyAll bool) *fbb.Message
 		ans := readLine()
 		if strings.EqualFold("y", ans) {
 			msg.Header.Set("X-P2POnly", "true")
+			msg.Header.Set("X-P2P", "true")
 		}
 	case 0:
 		fmt.Println("Message must have at least one recipient")
@@ -191,6 +192,7 @@ func noninteractiveComposeMessage(from string, subject string, attachments []str
 	msg.SetBody(string(body))
 	if p2pOnly {
 		msg.Header.Set("X-P2POnly", "true")
+		msg.Header.Set("X-P2P", "true")
 	}
 
 	postMessage(msg)

--- a/http.go
+++ b/http.go
@@ -315,6 +315,7 @@ func postOutboundMessageHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if v := r.Form["p2ponly"]; len(v) == 1 && v[0] != "" {
 		msg.Header.Set("X-P2POnly", "true")
+		msg.Header.Set("X-P2P", "true")
 	}
 	if v := r.Form["date"]; len(v) == 1 {
 		t, err := time.Parse(time.RFC3339, v[0])


### PR DESCRIPTION
Certain Winlink clients, specifically Winlink Express, expect P2P messages to have the X-P2P header present and set to True, for listing and reporting of P2P messages to work properly. Currently P2P messages received from Pat are not marked as P2P nor reported to the CMS (for US licensed stations).

This is a simple update to prove the concept, and alternatively the change could be to normalize the use of a single X-P2P header for the P2P Only cli and http/ui reporting. Messages received from WLE include the X-P2P header, and could be used to mark as P2P Only in the inbox, etc.