### PR TITLE
Further MPS Improvements

### DIFF
--- a/internal/cmsapi/hybrid_station.go
+++ b/internal/cmsapi/hybrid_station.go
@@ -1,0 +1,27 @@
+package cmsapi
+
+import (
+	"context"
+	"net/url"
+)
+
+const PathHybridStationList = "/hybridStation/list"
+
+type HybridStation struct {
+	Callsign            string
+	AutomaticForwarding bool
+	ManualForwarding    bool
+}
+
+func HybridStationList(ctx context.Context) ([]HybridStation, error) {
+	var resp struct {
+		HybridList     []HybridStation
+		ResponseStatus responseStatus
+	}
+
+	if err := getJSON(ctx, PathHybridStationList, url.Values{}, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.HybridList, resp.ResponseStatus.errorOrNil()
+}

--- a/internal/cmsapi/mps.go
+++ b/internal/cmsapi/mps.go
@@ -106,18 +106,3 @@ func MPSGet(ctx context.Context, requester, callsign string) ([]MessagePickupSta
 	}
 	return resp.MpsList, resp.ResponseStatus.errorOrNil()
 }
-
-// MPSList returns all MPS records
-func MPSList(ctx context.Context, requester string) ([]MessagePickupStationRecord, error) {
-	params := url.Values{
-		"requester": []string{requester},
-	}
-	var resp struct {
-		MpsList        []MessagePickupStationRecord `json:"mpsList"`
-		ResponseStatus responseStatus
-	}
-	if err := getJSON(ctx, PathMPSList, params, &resp); err != nil {
-		return nil, err
-	}
-	return resp.MpsList, resp.ResponseStatus.errorOrNil()
-}


### PR DESCRIPTION
* Update MPS list --all to use /hybridStation/list endpoint
* Prevent adding > 3 MPS, warn if adding a third

ref #51

I had a thought regarding the caching of the list --all endpoint. We could avoid a "force-download" flag like rmslist if we just always fetch the latest if we're online (there's no ratelimit). Then, we'd save a copy locally each time. If we're offline, we just reference the latest saved copy and show a warning to the user that it might be stale (and direct them to use an INQUIRY message). I could also be convinced to not cache anything and just direct to use an INQUIRY message on any mps-related failure.

As for the INQUIRY messages, I'm not sure of the best approach there. Should we introduce an "--offline" flag to all the MPS commands that generates an email? Do we want to automatically post that email to the outbox? Do we have good facilities for autogenerating emails already?