### PR TITLE
Add systemd user unit for running pat without root

### DIFF
--- a/debian/pat.service
+++ b/debian/pat.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=pat - Winlink client
+Documentation=https://github.com/la5nta/pat/wiki
+
+[Service]
+ExecStart=/usr/bin/pat http
+Restart=on-failure
+
+[Install]
+WantedBy=default.target

--- a/debian/rules
+++ b/debian/rules
@@ -20,10 +20,12 @@ binary-arch: clean build
 	mkdir -p $(PKGDIR)/usr/bin
 	mkdir -p $(PKGDIR)/usr/share/pat
 	mkdir -p $(PKGDIR)/lib/systemd/system
+	mkdir -p $(PKGDIR)/lib/systemd/user
 
 	mv ./pat $(PKGDIR)/usr/bin/
 	cp -r share/* $(PKGDIR)/usr/share/pat/
 	cp debian/pat@.service $(PKGDIR)/lib/systemd/system/
+	cp debian/pat.service $(PKGDIR)/lib/systemd/user/
 
 	dh_installman
 	dh_strip


### PR DESCRIPTION
## Summary

Finishes the systemd user-unit packaging started by @raek in #459
(WIP commit raek/pat@70005bb). That commit added `debian/pat.service`
but never created its install directory in `debian/rules`, which
would have broken the `.deb` build — fixed here.

## Why no ax25.service dependency is needed

@raek's stated concern was that a user-manager unit can't depend on
(`After=`) a system-manager unit like `ax25.service`, and worried
about a race condition on boot. Traced this in the Pat source:

- Outbound transports (Ardop/Vara/AGWPE/AX.25/Pactor) are only
  initialized inside `Connect()`, triggered by the user — nothing
  runs at startup (`app/connect.go`).
- Inbound listeners retry every second until their transport becomes
  available (`app/listener_hub.go`'s `listenLoop`), logging
  "Will try to re-establish listener in the background..." rather
  than failing. The underlying AX.25 port check
  (`wl2k-go/transport/ax25`'s `checkPort`) is a fast, non-blocking
  read, so this retry is bounded at ~1 second, not indefinite.

So no unit ordering against system services is required.

## Known limitation

Like any systemd user unit, this stops on logout and won't start at
boot unless the admin runs `sudo loginctl enable-linger <user>` once.
That's standard systemd behavior, not something this PR can fix, but
worth calling out explicitly here since it differs from the always-on
system unit.

## Test plan

- [x] `dpkg-buildpackage -us -uc -b` succeeds and the built `.deb`
      contains `lib/systemd/user/pat.service`, byte-for-byte identical
      to `debian/pat.service` in the repo
- [x] `go fmt ./...`, `go build ./...`, and `go test ./...` all pass
      (no Go code changed by this PR)
- [ ] `systemctl --user start pat` was **not** exercised against a real
      systemd user session — the environment this PR was developed in
      has no systemd/D-Bus user session available to test against. The
      unit's static syntax and packaging placement are verified; the
      actual start/stop/status lifecycle under `systemctl --user` still
      needs confirmation on a real system before merge.

Fixes #459
