### PR TITLE
Make the connect dialog and RMS list responsive

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Copyright (c) 2020 Martin Hebnes Pedersen LA5NTA
 * N2YGK - Alan Crosswell
 * VE7GNU - Doug Collinge
 * W6IPA  - JC Martin
+* W7AYU - Marc Thomson
 * WY2K - Benjamin Seidenberg
 
 ## Thanks to

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -156,85 +156,73 @@
             <h4 class="modal-title" id="myModalLabel">Connect to remote node...</h4>
           </div>
           <div class="modal-body">
-            <form class="form-horizontal" role="form" id="connectForm">
-              <div class="form-group">
-                <div class="col-md-11">
-                  <div class="form-group row">
-                    <div class="col-md-4">
-                      <div class="input-group">
-                        <select class="selectpicker form-control" data-width="100%" id="aliasSelect">
-                          <option value="">(select alias)</option>
-                        </select>
-                        <span class="input-group-btn">
-                          <button class="btn btn-default" type="button" id="aliasActionBtn" title="Save current configuration as new alias" style="display: none;">
-                            <span class="glyphicon glyphicon-plus"></span>
-                          </button>
-                        </span>
-                      </div>
-                    </div>
+            <form role="form" id="connectForm">
+              <div class="form-group row">
+                <div class="col-md-4">
+                  <div class="input-group">
+                    <select class="selectpicker form-control" data-width="100%" id="aliasSelect">
+                      <option value="">(select alias)</option>
+                    </select>
+                    <span class="input-group-btn">
+                      <button class="btn btn-default" type="button" id="aliasActionBtn" title="Save current configuration as new alias" style="display: none;">
+                        <span class="glyphicon glyphicon-plus"></span>
+                      </button>
+                    </span>
                   </div>
-                  <div class="form-group row">
-                    <label for="inputKey" class="col-md-2 control-label">transport:</label>
-                    <div class="col-md-4">
-                      <select class="selectpicker form-control" data-width="100%" id="transportSelect">
-                        <option value="ardop">ARDOP</option>
-                        <option value="ax25">AX.25</option>
-                        <option value="pactor">PACTOR</option>
-                        <option value="telnet">Telnet</option>
-                        <option value="varafm">VARA FM</option>
-                        <option value="varahf">VARA HF</option>
-                        <optgroup label="advanced">
-                          <option value="ax25+agwpe">AX.25+agwpe</option>
-                          <option value="ax25+linux">AX.25+linux</option>
-                          <option value="ax25+serial-tnc">AX.25+serial-tnc</option>
-                        </optgroup>
-                      </select>
-                    </div>
-                    <label for="targetInput" class="col-md-2 control-label">target:</label>
-                    <div class="col-md-4">
-                      <input type="text" class="form-control" id="targetInput" placeholder="N0CALL" />
-                    </div>
+                </div>
+              </div>
+              <div class="connect-field-row">
+                <div class="connect-field-col connect-field-col-half">
+                  <label for="transportSelect" class="control-label">Transport</label>
+                  <select class="selectpicker form-control" data-width="100%" id="transportSelect">
+                    <option value="ardop">ARDOP</option>
+                    <option value="ax25">AX.25</option>
+                    <option value="pactor">PACTOR</option>
+                    <option value="telnet">Telnet</option>
+                    <option value="varafm">VARA FM</option>
+                    <option value="varahf">VARA HF</option>
+                    <optgroup label="advanced">
+                      <option value="ax25+agwpe">AX.25+agwpe</option>
+                      <option value="ax25+linux">AX.25+linux</option>
+                      <option value="ax25+serial-tnc">AX.25+serial-tnc</option>
+                    </optgroup>
+                  </select>
+                </div>
+                <div class="connect-field-col connect-field-col-half">
+                  <label for="targetInput" class="control-label">Target</label>
+                  <input type="text" class="form-control" id="targetInput" placeholder="N0CALL" />
+                </div>
+              </div>
+              <div class="connect-field-row">
+                <div class="connect-field-col connect-field-col-half" id="freqInputDiv">
+                  <label for="freqInput" class="control-label">Frequency</label>
+                  <div class="input-group">
+                    <input type="text" class="form-control" id="freqInput" placeholder="0000.00" />
+                    <div class="input-group-addon">KHz</div>
                   </div>
-                  <div class="form-group row">
-                    <div id="freqInputDiv">
-                      <label for="freqInput" class="col-md-2 control-label">freq:</label>
-                      <div class="col-md-4">
-                        <div class="input-group">
-                          <input type="text" class="form-control" id="freqInput" placeholder="0000.00" />
-                          <div class="input-group-addon">KHz</div>
-                        </div>
-                      </div>
-                    </div>
-                    <div id="bandwidthInputDiv">
-                      <label for="bandwidthInput" class="col-md-2 control-label">
-                        bandwidth:
-                      </label>
-                      <div class="col-md-4">
-                        <select class="selectpicker form-control" data-width="100%" id="bandwidthInput"></select>
-                      </div>
-                    </div>
-                    <div id="addrInputDiv">
-                      <label for="addrInput" class="col-md-2 control-label">address:</label>
-                      <div class="col-md-10">
-                        <input type="text" class="form-control" id="addrInput" placeholder="user:pass@host:port" />
-                      </div>
-                    </div>
+                </div>
+                <div class="connect-field-col connect-field-col-half" id="bandwidthInputDiv">
+                  <label for="bandwidthInput" class="control-label">Bandwidth</label>
+                  <select class="selectpicker form-control" data-width="100%" id="bandwidthInput"></select>
+                </div>
+              </div>
+              <div class="connect-field-row">
+                <div class="connect-field-col" id="addrInputDiv">
+                  <label for="addrInput" class="control-label">Address</label>
+                  <input type="text" class="form-control" id="addrInput" placeholder="user:pass@host:port" />
+                </div>
+              </div>
+              <div class="connect-field-row">
+                <div class="connect-field-col connect-field-col-half" id="connectRequestsInputDiv">
+                  <label for="connectRequestsInput" class="control-label">Tries</label>
+                  <div class="input-group" data-toggle="tooltip" title="Maximum number of ARDOP connect request frames to transmit. Most stations require multiple tries before responding.">
+                    <input type="number" class="form-control" id="connectRequestsInput" min="1" />
+                    <div class="input-group-addon">frames</div>
                   </div>
-                  <div class="form-group row" id="connectRequestsInputDiv">
-                    <label for="connectRequestsInput" class="col-md-2 control-label">tries:</label>
-                    <div class="col-md-4">
-                      <div class="input-group" data-toggle="tooltip" title="Maximum number of ARDOP connect request frames to transmit. Most stations require multiple tries before responding.">
-                        <input type="number" class="form-control" id="connectRequestsInput" min="1" />
-                        <div class="input-group-addon">frames</div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="form-group row" id="checkboxInput">
-                    <div class="col-md-5" id="radioOnlyInputDiv">
-                      <div class="input-group col-md-9">
-                        <label><input type="checkbox" id="radioOnlyInput" /> Radio Only</label>
-                      </div>
-                    </div>
+                </div>
+                <div class="connect-field-col connect-field-col-half" id="radioOnlyInputDiv">
+                  <div class="checkbox">
+                    <label><input type="checkbox" id="radioOnlyInput" /> Radio Only</label>
                   </div>
                 </div>
               </div>
@@ -254,7 +242,7 @@
           </div>
           <div class="modal-footer collapse" id="rmslist-container">
             <div class="form-group row">
-              <div class="col-md-3">
+              <div class="col-xs-6 col-sm-3 rms-filter-col">
                 <select class="selectpicker form-control" data-width="100%" id="modeSearchSelect">
                   <optgroup label="mode">
                     <option value="">(any mode)</option>
@@ -266,7 +254,7 @@
                   </optgroup>
                 </select>
               </div>
-              <div class="col-md-3">
+              <div class="col-xs-6 col-sm-3 rms-filter-col">
                 <select class="selectpicker form-control" data-width="100%" id="bandSearchSelect">
                   <optgroup label="band">
                     <!-- Values from freq.go -->
@@ -289,10 +277,10 @@
                   </optgroup>
                 </select>
               </div>
-              <div class="col-md-3">
+              <div class="col-xs-6 col-sm-3 rms-filter-col">
                 <input type="text" class="form-control" id="targetFilterInput" placeholder="(any target)">
               </div>
-              <div class="col-md-3">
+              <div class="col-xs-6 col-sm-3 rms-filter-col">
                 <button id="updateRmslistButton" class="btn btn-default btn-link">
                   Update cache
                 </button>

--- a/web/src/scss/app.scss
+++ b/web/src/scss/app.scss
@@ -542,3 +542,52 @@ input[type='radio'] {
 #createAccountModal #step4 .checkbox {
   margin-bottom: 20px;
 }
+
+// Connect modal: form fields stack on narrow screens and pair up from
+// 600px. A custom breakpoint is used instead of Bootstrap's stock
+// col-sm-* (768px breakpoint) because common phone-landscape viewports
+// (600-750px, e.g. iPhone SE/8 at 667px) fall below 768px -- stock
+// col-sm-6 would still collapse to one column on exactly the case
+// issue #220 asked to preserve as 2-up.
+//
+// Named connect-field-* (not form-row/form-col) to avoid reading like
+// Bootstrap 4's grid classes on this Bootstrap 3 project.
+#connectModal .connect-field-row {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+#connectModal .connect-field-col {
+  width: 100%;
+  padding: 0 10px;
+  margin-bottom: 10px;
+  box-sizing: border-box;
+}
+
+@media (min-width: 600px) {
+  #connectModal .connect-field-col-half {
+    width: 50%;
+  }
+}
+
+#connectModal .checkbox {
+  // Vertically align the Radio Only checkbox with its row-mate (the
+  // Tries field), which has a label above its input -- without this,
+  // the checkbox sits noticeably higher since it has no label of its own.
+  margin-top: 25px;
+}
+
+#connectModal .checkbox label {
+  display: flex;
+  align-items: center;
+}
+
+// RMS list filter row: mode/band/target/update-cache stay paired 2-up
+// even at phone width (they're short controls, not long labeled
+// fields), only dropping to a single column below Bootstrap's smallest
+// breakpoint floor.
+@media (max-width: 359px) {
+  #rmslist-container .rms-filter-col {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary

Reworks the connect dialog's form and the RMS list filter row so they actually use the modal's full width and work well on phones/tablets in landscape, per @martinhpedersen's two stated requirements in #220.

- Connect form fields (Transport/Target/Frequency/Bandwidth/Address/Tries/Radio Only) now use a label-on-top, 2-up grid that pairs up above a **custom ~600px breakpoint**, replacing the old `col-md-4`/`col-md-2` pairs that only responded to Bootstrap's 992px breakpoint.
- The RMS list filter row (mode/band/target/update-cache) now stays paired 2-up down to phone width (`col-xs-6`/`col-sm-3`), only dropping to a single column below ~360px.
- `freq:` is spelled out to `Frequency`, per the issue's suggestion.
- Cleaned up a few things directly on the lines being rewritten anyway: a dead `for="inputKey"` label reference, an unused `col-md-11` width cap that was fighting against using the modal's full width, and an unused `id="checkboxInput"` wrapper.

## Why a custom breakpoint instead of Bootstrap's stock `col-sm-6`

Bootstrap 3's `sm` breakpoint (768px) is the same width where `.modal-dialog` switches to its fixed 600px size. Common phone-landscape viewports (iPhone SE/8: 667px; many Android phones: 600–750px) fall *below* 768px, so stock `col-sm-6` would still collapse the form to one column on exactly the case the maintainer called out as the priority. Verified against Bootstrap 3's documented breakpoint values before choosing an alternative: both the connect form and the RMS list panel use a small custom `@media` rule instead (see `web/src/scss/app.scss`), at thresholds tuned to each one's content (~600px for labeled form fields, ~360px floor for compact filter controls).

## Test plan

- [x] Live-verified in a real browser: opened the connect modal, cycled Transport through ARDOP → Telnet → AX.25 → back to ARDOP, confirmed every show/hide transition (Frequency+Bandwidth vs. Address, Tries+Radio Only) works with no leftover empty-height gap, and no JS console errors at any step.
- [x] `go fmt ./...`, `go build ./...`, `go test ./...` all pass (this PR touches no `.go` files — only `web/src/index.html` and `web/src/scss/app.scss`, with `web/dist/*` regenerated by the normal build).
- [x] Screenshots captured at four widths (1024px, 667px — a real phone-landscape width, e.g. iPhone SE/8 — 375px, and 320px), covering the default (ARDOP) state, the Telnet state (Address field), and the expanded RMS list panel at each width. Attached below.

### Screenshots

**1024px**
<img width="2048" height="1842" alt="1024_ARDOP" src="https://github.com/user-attachments/assets/2d449b5b-cef7-47b1-9b94-9c4c0fc40597" />
<img width="2048" height="1842" alt="1024_ARDOP_RMS" src="https://github.com/user-attachments/assets/434d01c1-6934-4c06-b098-55e5deba8ad7" />
<img width="2048" height="1842" alt="1024_telnet" src="https://github.com/user-attachments/assets/c986ca02-164a-473c-9784-84323bbd6960" />


**667px (phone landscape)**
<img width="1334" height="1382" alt="667_ARDOP" src="https://github.com/user-attachments/assets/4fd5c831-8664-4a27-ae7c-c7dac8640287" />
<img width="1334" height="1382" alt="667_ARDOP_RMS" src="https://github.com/user-attachments/assets/509cdaaf-20c1-448c-8a1f-d43a8371d024" />
<img width="1334" height="1382" alt="667_telnet" src="https://github.com/user-attachments/assets/a23cbbf7-7886-49f8-8269-d710e4ea7df7" />


**375px**
<img width="750" height="1382" alt="375_telnet" src="https://github.com/user-attachments/assets/3ca03bd7-12e4-456a-9c62-9ca9905abe3f" />
<img width="750" height="1382" alt="375_ARDOP" src="https://github.com/user-attachments/assets/7f474cd3-1e24-4579-acf0-96bbc0bdc22d" />
<img width="750" height="1382" alt="375_ARDOP_RMS" src="https://github.com/user-attachments/assets/79cc535f-356e-4d56-82de-86a9cfded46b" />


**320px**
<img width="640" height="1382" alt="320_ARDOP" src="https://github.com/user-attachments/assets/6e146a85-0774-4e9d-b21a-ef956d4047f9" />
<img width="640" height="1382" alt="320_ARDOP_RMS" src="https://github.com/user-attachments/assets/d5990813-1868-4765-b7ab-f3f4dcfdd412" />
<img width="640" height="1382" alt="320_telnet" src="https://github.com/user-attachments/assets/228aa2d9-9f5e-41ea-b727-816bb8d80a48" />

Fixes #220
