### PR TITLE
manpage typo fix

### DIFF
--- a/man/pat.1
+++ b/man/pat.1
@@ -49,7 +49,7 @@ Path to config file (located in the \fIPAT_CONFIG_PATH\fP returned from \fIpat e
 Path to event log file (located in the \fIPAT_CONFIG_PATH\fP returned from \fIpat env\fP).
 .TP
 \fR--ignore-busy\fP
-Don't wait for clear channel before connevting to a node.
+Don't wait for clear channel before connecting to a node.
 .TP
 \fR-l, --listen string\fP
 Comma-separated list of methods to listen on (e.g. ardop,telnet,ax25).


### PR DESCRIPTION
fix "connevting" -> "connecting" typo in --ignore-busy manpage entry